### PR TITLE
Wang yi fei

### DIFF
--- a/include/corona/spatial/octree.h
+++ b/include/corona/spatial/octree.h
@@ -12,29 +12,19 @@
 
 namespace Corona::Spatial {
 
-/**
- * @brief 八叉树调参
- *
- * 该结构与 mechanics_system.cpp 中 file-local 实现的常量保持兼容，
- * 便于后续把物理系统的实现迁移到 SceneSystem 时无回归差异。
- */
 struct OctreeConfig {
-    int   max_depth            = 6;       ///< 最大递归深度
-    int   max_objects_per_leaf = 4;       ///< 叶节点容量阈值，超过则尝试分裂
-    float root_padding         = 0.01f;   ///< 根盒外扩，防边界物体跨层抖振
+    int   max_depth            = 6;
+    int   max_objects_per_leaf = 4;
+    float root_padding         = 0.01f;
 };
 
 /**
- * @brief 通用模板化八叉树
+ * @brief 通用模板化八叉树（递归空间分区）
  *
  * @tparam TPayload 叶节点存储的载荷类型，要求可拷贝/可移动且可比较（用于 dedupe）。
  *
- * 设计目标：
- * - 由 SceneSystem 在 update() 中独占重建（rebuild），其它系统只读查询；
- * - 当前版本仅实现 rebuild + 查询，增量 insert/remove 留给后续优化。
- *
- * 所有查询接口当前为骨架实现：rebuild 后返回所有 entry（暴力遍历）。
- * 后续在 M1.2 中替换为真正的递归剪枝。
+ * 由 SceneSystem 在 update() 中独占重建（rebuild），其它系统只读查询。
+ * 所有查询接口采用递归剪枝，节点 bounds 不相交时跳过整棵子树。
  */
 template <typename TPayload>
 class Octree {
@@ -47,93 +37,279 @@ class Octree {
     explicit Octree(OctreeConfig cfg = {}) : cfg_(cfg) {}
 
     void clear() noexcept {
-        entries_.clear();
-        root_bounds_ = AABB{};
+        root_.reset();
     }
 
     /**
      * @brief 全量重建八叉树
      * @param root      场景根 AABB（已含 padding）
      * @param entries   所有需要插入的载荷
-     *
-     * 当前实现：仅缓存条目；查询走暴力遍历。
      */
     void rebuild(const AABB& root, std::span<const Entry> entries) {
-        root_bounds_ = root;
-        entries_.assign(entries.begin(), entries.end());
-        // TODO(M1.2): 构造真实的八叉树节点结构
+        root_ = std::make_unique<Node>();
+        root_->bounds = root;
+        for (const auto& e : entries) {
+            insert(root_.get(), e, 0);
+        }
     }
 
-    [[nodiscard]] const AABB& root_bounds() const noexcept { return root_bounds_; }
-    [[nodiscard]] std::size_t  size()        const noexcept { return entries_.size(); }
-    [[nodiscard]] bool         empty()       const noexcept { return entries_.empty(); }
+    [[nodiscard]] const AABB& root_bounds() const noexcept {
+        static const AABB kEmpty{};
+        return root_ ? root_->bounds : kEmpty;
+    }
+
+    [[nodiscard]] std::size_t size() const noexcept {
+        return count_entries(root_.get());
+    }
+
+    [[nodiscard]] bool empty() const noexcept {
+        return !root_ || count_entries(root_.get()) == 0;
+    }
+
+    [[nodiscard]] const OctreeConfig& config() const noexcept { return cfg_; }
 
     // ============================================================
-    // 查询接口（M1.2 之前为暴力实现）
+    // 查询接口（递归 + 剪枝）
     // ============================================================
 
     void query_aabb(const AABB& box, std::vector<TPayload>& out) const {
-        for (const Entry& e : entries_) {
-            if (e.bounds.overlaps(box)) {
-                out.push_back(e.payload);
-            }
-        }
+        if (!root_) return;
+        query_aabb_impl(root_.get(), box, out);
     }
 
     void query_sphere(const ktm::fvec3& center, float radius,
                       std::vector<TPayload>& out) const {
-        const float r2 = radius * radius;
-        for (const Entry& e : entries_) {
-            // AABB 到球心的最近点距离平方
-            float dx = std::max({e.bounds.min.x - center.x, 0.0f, center.x - e.bounds.max.x});
-            float dy = std::max({e.bounds.min.y - center.y, 0.0f, center.y - e.bounds.max.y});
-            float dz = std::max({e.bounds.min.z - center.z, 0.0f, center.z - e.bounds.max.z});
-            if (dx * dx + dy * dy + dz * dz <= r2) {
-                out.push_back(e.payload);
-            }
-        }
+        if (!root_) return;
+        query_sphere_impl(root_.get(), center, radius, out);
     }
 
-    /**
-     * @brief 自定义谓词查询（视锥剔除等可基于此封装）
-     */
     template <typename Predicate>
     void query_if(Predicate&& pred, std::vector<TPayload>& out) const {
-        for (const Entry& e : entries_) {
-            if (pred(e.bounds)) out.push_back(e.payload);
-        }
+        if (!root_) return;
+        query_if_impl(root_.get(), pred, out);
     }
 
-    /**
-     * @brief 收集所有可能碰撞的 payload 对（i<j，已 dedupe）
-     */
     void collect_pairs(std::vector<std::pair<TPayload, TPayload>>& out) const {
-        for (std::size_t i = 0; i < entries_.size(); ++i) {
-            for (std::size_t j = i + 1; j < entries_.size(); ++j) {
-                if (entries_[i].bounds.overlaps(entries_[j].bounds)) {
-                    out.emplace_back(entries_[i].payload, entries_[j].payload);
-                }
-            }
-        }
+        if (!root_) return;
+        collect_pairs_impl(root_.get(), out);
     }
 
     struct Stats {
         std::size_t entries        = 0;
-        int         nodes          = 0;   // M1.2 后填入
+        int         nodes          = 0;
         int         leaves         = 0;
         int         max_depth_used = 0;
     };
 
     [[nodiscard]] Stats stats() const noexcept {
         Stats s;
-        s.entries = entries_.size();
+        gather_stats(root_.get(), s, 0);
         return s;
     }
 
    private:
-    OctreeConfig       cfg_;
-    AABB               root_bounds_{};
-    std::vector<Entry> entries_;
+    struct Node {
+        AABB                                bounds;
+        std::vector<Entry>                  entries;   // 叶节点=全部对象；内部节点=跨分割面的对象
+        std::array<std::unique_ptr<Node>, 8> children{};
+        bool                                is_leaf = true;
+    };
+
+    static int octant_index(const ktm::fvec3& center, const ktm::fvec3& point) {
+        return (point.x >= center.x ? 1 : 0)
+             | (point.y >= center.y ? 2 : 0)
+             | (point.z >= center.z ? 4 : 0);
+    }
+
+    static AABB child_bounds(const AABB& parent, int octant) {
+        ktm::fvec3 c = parent.center();
+        AABB child;
+        child.min.x = (octant & 1) ? c.x : parent.min.x;
+        child.max.x = (octant & 1) ? parent.max.x : c.x;
+        child.min.y = (octant & 2) ? c.y : parent.min.y;
+        child.max.y = (octant & 2) ? parent.max.y : c.y;
+        child.min.z = (octant & 4) ? c.z : parent.min.z;
+        child.max.z = (octant & 4) ? parent.max.z : c.z;
+        return child;
+    }
+
+    int fits_in_one_octant(const AABB& parent, const AABB& box) const {
+        ktm::fvec3 c = parent.center();
+        int idx_min = octant_index(c, box.min);
+        int idx_max = octant_index(c, box.max);
+        return (idx_min == idx_max) ? idx_min : -1;
+    }
+
+    void subdivide(Node* node) {
+        ktm::fvec3 c = node->bounds.center();
+        for (int i = 0; i < 8; ++i) {
+            node->children[i] = std::make_unique<Node>();
+            node->children[i]->bounds = child_bounds(node->bounds, i);
+        }
+        node->is_leaf = false;
+
+        std::vector<Entry> old_entries;
+        old_entries.swap(node->entries);
+        for (const auto& e : old_entries) {
+            int idx = fits_in_one_octant(node->bounds, e.bounds);
+            if (idx >= 0) {
+                node->children[idx]->entries.push_back(e);
+            } else {
+                node->entries.push_back(e);
+            }
+        }
+    }
+
+    void insert(Node* node, const Entry& entry, int depth) {
+        if (node->is_leaf) {
+            if (static_cast<int>(node->entries.size()) < cfg_.max_objects_per_leaf
+                || depth >= cfg_.max_depth) {
+                node->entries.push_back(entry);
+                return;
+            }
+            subdivide(node);
+        }
+
+        int idx = fits_in_one_octant(node->bounds, entry.bounds);
+        if (idx >= 0) {
+            insert(node->children[idx].get(), entry, depth + 1);
+        } else {
+            node->entries.push_back(entry);
+        }
+    }
+
+    static std::size_t count_entries(const Node* node) {
+        if (!node) return 0;
+        std::size_t n = node->entries.size();
+        for (const auto& child : node->children) {
+            if (child) n += count_entries(child.get());
+        }
+        return n;
+    }
+
+    // === 递归查询 ===
+
+    static void query_aabb_impl(const Node* node, const AABB& box,
+                                std::vector<TPayload>& out) {
+        if (!node->bounds.overlaps(box)) return;
+        for (const auto& e : node->entries) {
+            if (e.bounds.overlaps(box)) out.push_back(e.payload);
+        }
+        for (const auto& child : node->children) {
+            if (child) query_aabb_impl(child.get(), box, out);
+        }
+    }
+
+    static void query_sphere_impl(const Node* node, const ktm::fvec3& center,
+                                  float radius, std::vector<TPayload>& out) {
+        float r2 = radius * radius;
+        float dx = std::max({node->bounds.min.x - center.x, 0.0f, center.x - node->bounds.max.x});
+        float dy = std::max({node->bounds.min.y - center.y, 0.0f, center.y - node->bounds.max.y});
+        float dz = std::max({node->bounds.min.z - center.z, 0.0f, center.z - node->bounds.max.z});
+        if (dx * dx + dy * dy + dz * dz > r2) return;
+
+        for (const auto& e : node->entries) {
+            dx = std::max({e.bounds.min.x - center.x, 0.0f, center.x - e.bounds.max.x});
+            dy = std::max({e.bounds.min.y - center.y, 0.0f, center.y - e.bounds.max.y});
+            dz = std::max({e.bounds.min.z - center.z, 0.0f, center.z - e.bounds.max.z});
+            if (dx * dx + dy * dy + dz * dz <= r2) out.push_back(e.payload);
+        }
+        for (const auto& child : node->children) {
+            if (child) query_sphere_impl(child.get(), center, radius, out);
+        }
+    }
+
+    template <typename Predicate>
+    static void query_if_impl(const Node* node, Predicate& pred,
+                              std::vector<TPayload>& out) {
+        if (!pred(node->bounds)) return;
+        for (const auto& e : node->entries) {
+            if (pred(e.bounds)) out.push_back(e.payload);
+        }
+        for (const auto& child : node->children) {
+            if (child) query_if_impl(child.get(), pred, out);
+        }
+    }
+
+    static void collect_all_entries(const Node* node, std::vector<const Entry*>& out) {
+        if (!node) return;
+        for (const auto& e : node->entries) out.push_back(&e);
+        for (const auto& child : node->children) {
+            if (child) collect_all_entries(child.get(), out);
+        }
+    }
+
+    static void collect_pairs_impl(const Node* node,
+                                   std::vector<std::pair<TPayload, TPayload>>& out) {
+        if (!node) return;
+
+        if (node->is_leaf) {
+            for (std::size_t i = 0; i < node->entries.size(); ++i) {
+                for (std::size_t j = i + 1; j < node->entries.size(); ++j) {
+                    if (node->entries[i].bounds.overlaps(node->entries[j].bounds)) {
+                        auto a = node->entries[i].payload;
+                        auto b = node->entries[j].payload;
+                        out.emplace_back(a < b ? a : b, a < b ? b : a);
+                    }
+                }
+            }
+            return;
+        }
+
+        // 跨分割条目间的对
+        for (std::size_t i = 0; i < node->entries.size(); ++i) {
+            for (std::size_t j = i + 1; j < node->entries.size(); ++j) {
+                if (node->entries[i].bounds.overlaps(node->entries[j].bounds)) {
+                    auto a = node->entries[i].payload;
+                    auto b = node->entries[j].payload;
+                    out.emplace_back(a < b ? a : b, a < b ? b : a);
+                }
+            }
+        }
+
+        // 收集每个子树的所有条目
+        std::array<std::vector<const Entry*>, 8> child_entries;
+        for (int c = 0; c < 8; ++c) {
+            if (node->children[c]) {
+                collect_all_entries(node->children[c].get(), child_entries[c]);
+            }
+        }
+
+        // 跨分割条目 vs 每个子树的条目
+        for (const auto& straddle : node->entries) {
+            for (int c = 0; c < 8; ++c) {
+                for (const auto* e : child_entries[c]) {
+                    if (straddle.bounds.overlaps(e->bounds)) {
+                        auto a = straddle.payload;
+                        auto b = e->payload;
+                        out.emplace_back(a < b ? a : b, a < b ? b : a);
+                    }
+                }
+            }
+        }
+
+        // 递归子节点
+        for (const auto& child : node->children) {
+            if (child) collect_pairs_impl(child.get(), out);
+        }
+    }
+
+    static void gather_stats(const Node* node, Stats& s, int depth) {
+        if (!node) return;
+        s.entries += node->entries.size();
+        ++s.nodes;
+        s.max_depth_used = std::max(s.max_depth_used, depth);
+        if (node->is_leaf) {
+            ++s.leaves;
+        } else {
+            for (const auto& child : node->children) {
+                if (child) gather_stats(child.get(), s, depth + 1);
+            }
+        }
+    }
+
+    OctreeConfig            cfg_;
+    std::unique_ptr<Node>   root_;
 };
 
 }  // namespace Corona::Spatial

--- a/include/corona/systems/mechanics/mechanics_system.h
+++ b/include/corona/systems/mechanics/mechanics_system.h
@@ -61,6 +61,7 @@ class MechanicsSystem : public Kernel::SystemBase {
     // 力学系统私有成员
     void update_physics();
 
+    Kernel::ISystemContext* m_ctx = nullptr;
     float m_time_accumulator{0.0f};
     std::chrono::steady_clock::time_point m_last_update_time{};
     bool m_first_update{true};

--- a/include/corona/systems/scene/scene_system.h
+++ b/include/corona/systems/scene/scene_system.h
@@ -97,6 +97,19 @@ class SceneSystem : public Kernel::SystemBase {
     void               mark_actor_restored(std::uintptr_t actor);
 
     // ========================================
+    // LOD 工具
+    // ========================================
+    /// 计算物体包围球在屏幕上的占比（0~1）
+    static float compute_screen_ratio(const ktm::fvec3& camera_pos,
+                                      float              camera_fov_deg,
+                                      const ktm::fvec3& world_center,
+                                      float              bounding_radius);
+
+    /// 根据屏幕占比选择 LOD 等级（0 = 原始网格）
+    static int select_lod_level(float                     screen_ratio,
+                                const std::vector<float>& thresholds);
+
+    // ========================================
     // 统计
     // ========================================
     [[nodiscard]] SceneStats stats(std::uintptr_t scene) const;

--- a/src/systems/mechanics/mechanics_system.cpp
+++ b/src/systems/mechanics/mechanics_system.cpp
@@ -3,8 +3,8 @@
 #include <corona/kernel/core/i_logger.h>
 #include <corona/kernel/event/i_event_bus.h>
 #include <corona/kernel/event/i_event_stream.h>
-#include <corona/spatial/octree.h>
 #include <corona/systems/mechanics/mechanics_system.h>
+#include <corona/systems/scene/scene_system.h>
 
 #include <algorithm>      // min,max,clamp,sort,unique
 #include <array>          // std::array（八叉树子节点）
@@ -89,18 +89,22 @@ inline ktm::fvec3 transform_local_point_to_world(const Corona::ModelTransform& t
 inline void world_aabb_from_local_bounds(const Corona::ModelTransform& t,
                                          const ktm::fvec3& lmin, const ktm::fvec3& lmax,
                                          ktm::fvec3& out_min, ktm::fvec3& out_max, ktm::fvec3& out_center) {
-    ktm::fvec3 c0 = transform_local_point_to_world(t, make_fvec3(lmin.x, lmin.y, lmin.z));  // 角点 (min,min,min)
-    out_min = c0;                                                                           // 初始化 min
-    out_max = c0;                                                                           // 初始化 max
-    for (int i = 1; i < 8; ++i) {                                                           // i 从 1 到 7：其余顶点
-        const float x = (i & 1) != 0 ? lmax.x : lmin.x;                                     // 按位选 min 或 max
-        const float y = (i & 2) != 0 ? lmax.y : lmin.y;
-        const float z = (i & 4) != 0 ? lmax.z : lmin.z;
-        const ktm::fvec3 wp = transform_local_point_to_world(t, make_fvec3(x, y, z));  // 世界顶点
-        out_min.x = std::min(out_min.x, wp.x);                                         // 扩张 min.x
+    // 局部 AABB 的 8 个角点：min/max 各分量组合 → 世界空间 → 取包络
+    const ktm::fvec3 corners[8] = {
+        {lmin.x, lmin.y, lmin.z}, {lmax.x, lmin.y, lmin.z},
+        {lmin.x, lmax.y, lmin.z}, {lmax.x, lmax.y, lmin.z},
+        {lmin.x, lmin.y, lmax.z}, {lmax.x, lmin.y, lmax.z},
+        {lmin.x, lmax.y, lmax.z}, {lmax.x, lmax.y, lmax.z},
+    };
+    ktm::fvec3 wp0 = transform_local_point_to_world(t, corners[0]);
+    out_min = wp0;
+    out_max = wp0;
+    for (int i = 1; i < 8; ++i) {
+        const ktm::fvec3 wp = transform_local_point_to_world(t, corners[i]);
+        out_min.x = std::min(out_min.x, wp.x);
         out_min.y = std::min(out_min.y, wp.y);
         out_min.z = std::min(out_min.z, wp.z);
-        out_max.x = std::max(out_max.x, wp.x);  // 扩张 max.x
+        out_max.x = std::max(out_max.x, wp.x);
         out_max.y = std::max(out_max.y, wp.y);
         out_max.z = std::max(out_max.z, wp.z);
     }
@@ -761,7 +765,7 @@ void triangle_narrowphase(
 namespace Corona::Systems {
 
 bool MechanicsSystem::initialize(Kernel::ISystemContext* ctx) {
-    (void)ctx;
+    m_ctx = ctx;
     g_shutdown_requested = false;
     CFW_LOG_INFO("MechanicsSystem initialized");
     return true;
@@ -1030,35 +1034,6 @@ void MechanicsSystem::update_physics() {
         mechanics_data.push_back(entry);
     }
 
-    // --- 阶段 4：把所有物体的世界 AABB 并起来写入 Scene（供裁剪/调试等），并把 floor_y 纳入场景包围，避免物体落地面却被剔除 ---
-    if (!mechanics_data.empty()) {
-        ktm::fvec3 scene_min = mechanics_data[0].min_world;  // 世界 AABB 最小角
-        ktm::fvec3 scene_max = mechanics_data[0].max_world;  // 世界 AABB 最大角
-
-        for (const auto& e : mechanics_data) {
-            scene_min.x = std::min(scene_min.x, e.min_world.x);  // 逐轴扩张包络
-            scene_min.y = std::min(scene_min.y, e.min_world.y);
-            scene_min.z = std::min(scene_min.z, e.min_world.z);
-            scene_max.x = std::max(scene_max.x, e.max_world.x);
-            scene_max.y = std::max(scene_max.y, e.max_world.y);
-            scene_max.z = std::max(scene_max.z, e.max_world.z);
-        }
-        scene_min.y = std::min(scene_min.y, floor_y - floor_eps);  // 下移 min.y，保证地板带进入 Scene AABB
-
-        ktm::fvec3 scene_center = make_fvec3(
-            (scene_min.x + scene_max.x) * 0.5f,
-            (scene_min.y + scene_max.y) * 0.5f,
-            (scene_min.z + scene_max.z) * 0.5f);
-
-        for (auto sh : scene_handles) {  // 每个被遍历过的 scene 写同一套包围（多场景时行为一致）
-            if (auto s_w = scene_storage.acquire_write(sh)) {
-                s_w->min_world = scene_min;
-                s_w->max_world = scene_max;
-                s_w->center_world = scene_center;
-            }
-        }
-    }
-
     // 预加载所有物理物体的碰撞网格（用于三角形碰撞检测和精确地板碰撞）
     for (const auto& entry : mechanics_data) {
         if (entry.model_id != 0) {
@@ -1069,48 +1044,42 @@ void MechanicsSystem::update_physics() {
     // 临时校正表：记录 Phase 5 末轮的位置校正量，在 Phase 6 积分后统一应用
     std::unordered_map<std::uintptr_t, ktm::fvec3> position_correction;
 
-    // --- 阶段 5：八叉树粗测 → 世界 AABB 再筛 → 窄相（AABB 或 OBB+SAT）→ 顺序冲量 + 摩擦 + 末轮位置校正 ---
+    // 阶段 5：从 SceneSystem 获取宽相候选对 → 窄相（AABB 或 OBB+SAT）→ 顺序冲量 + 摩擦 + 末轮位置校正 ---
+    //SceneSystem 八叉树 payload 是 actor_handle，query_pairs() 返回 (actor_a, actor_b)
+    //一个 actor 可能挂多个含 mechanics 的 profile，故用 vector 存储所有 mechanics_handle
+    //转换时展开笛卡尔积；遍历 actor_a 的每个 mechanics vs actor_b 的每个 mechanics
+
+    // 构建 actor_handle → vector<mechanics_handle> 反向映射
+    std::unordered_map<std::uintptr_t, std::vector<std::uintptr_t>> actor_to_mech;
+    for (const auto& [mh, ah] : mech_to_actor) {
+        actor_to_mech[ah].push_back(mh);
+    }
+
+    std::vector<std::pair<std::uintptr_t, std::uintptr_t>> collision_pairs;
+    collision_pairs.reserve(mechanics_data.size() * 4);
+
+    // 通过 ISystemContext 获取 SceneSystem 指针，调用其八叉树的 query_pairs()
+    // 宽相阶段由 SceneSystem 维护的八叉树统一服务，MechanicsSystem 不再自建本地 octree
+    auto* scene_sys = dynamic_cast<SceneSystem*>(m_ctx->get_system("Scene"));
+    if (scene_sys) {
+        for (auto sh : scene_handles) {
+            auto actor_pairs = scene_sys->query_pairs(sh);
+            for (const auto& [ah, bh] : actor_pairs) {
+                auto it_a = actor_to_mech.find(ah);
+                auto it_b = actor_to_mech.find(bh);
+                if (it_a == actor_to_mech.end() || it_b == actor_to_mech.end()) continue;
+
+                // 展开一个 actor 挂多个 mechanics 的所有组合（笛卡尔积）
+                for (auto mh_a : it_a->second) {
+                    for (auto mh_b : it_b->second) {
+                        collision_pairs.emplace_back(mh_a, mh_b);
+                    }
+                }
+            }
+        }
+    }
+
     if (mechanics_data.size() >= 2) {
-        // 5.1 用全体物体世界 AABB 建略大于一切的轴对齐根盒子（pad 防边界物体漏分桶）
-        ktm::fvec3 root_min = mechanics_data[0].min_world;
-        ktm::fvec3 root_max = mechanics_data[0].max_world;
-        for (const auto& e : mechanics_data) {
-            root_min.x = std::min(root_min.x, e.min_world.x);
-            root_min.y = std::min(root_min.y, e.min_world.y);
-            root_min.z = std::min(root_min.z, e.min_world.z);
-            root_max.x = std::max(root_max.x, e.max_world.x);
-            root_max.y = std::max(root_max.y, e.max_world.y);
-            root_max.z = std::max(root_max.z, e.max_world.z);
-        }
-        // 扩展根节点边界，包含地板
-        root_min.y = std::min(root_min.y, floor_y - floor_eps);
-        const float pad = 0.01f;  // 米级小膨胀；过小可能使 AABB 贴边物体跨层不稳
-        root_min = make_fvec3(root_min.x - pad, root_min.y - pad, root_min.z - pad);
-        root_max = make_fvec3(root_max.x + pad, root_max.y + pad, root_max.z + pad);
-
-        // 5.2 使用通用 Octree 生成宽相候选对（Octree 模块已迁移出 MechanicsSystem）
-        Spatial::Octree<std::uintptr_t> tree;
-        std::vector<Spatial::Octree<std::uintptr_t>::Entry> entries;
-        entries.reserve(mechanics_data.size());
-
-        for (const auto& e : mechanics_data) {
-            Spatial::AABB b;
-            b.min = e.min_world;
-            b.max = e.max_world;
-            entries.push_back({e.handle, b});
-        }
-
-        Spatial::AABB root;
-        root.min = root_min;
-        root.max = root_max;
-        tree.rebuild(root, entries);
-
-        std::vector<std::pair<std::uintptr_t, std::uintptr_t>> collision_pairs;
-        collision_pairs.reserve(mechanics_data.size() * 4);
-        tree.collect_pairs(collision_pairs);
-
-        // CFW_LOG_DEBUG("Detected {} potential collision pairs", collision_pairs.size());
-
         // 碰撞对跟踪（用于回调通知 collision start/end）
         std::unordered_set<std::pair<std::uintptr_t, std::uintptr_t>, PairHash> curr_active_collisions;
 

--- a/src/systems/scene/scene_system.cpp
+++ b/src/systems/scene/scene_system.cpp
@@ -4,6 +4,7 @@
 #include <corona/spatial/octree.h>
 #include <corona/systems/scene/scene_system.h>
 
+#include <algorithm>
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
@@ -56,14 +57,140 @@ bool SceneSystem::initialize(Kernel::ISystemContext* ctx) {
 }
 
 void SceneSystem::update() {
-    // M1.1 TODO:
-    //   1) 遍历 SharedDataHub::scene_storage()，对每个 scene：
-    //      - 从 actor_handles 出发，沿 ActorDevice → ProfileDevice → MechanicsDevice
-    //        读取 (min_xyz, max_xyz)，构造 Octree::Entry 列表；
-    //      - 计算 root AABB（merge + padding），调用 tree.rebuild(root, entries)；
-    //      - 写回 SceneDevice.{min_world,max_world,center_world}（迁移阶段先不动，
-    //        与 MechanicsSystem 重复计算可接受）。
-    //   2) 收集本帧所有相机的可见集并集，更新 invisible_frames，按阈值发 Evict 事件。
+    auto& hub = SharedDataHub::instance();
+    auto& scene_storage     = hub.scene_storage();
+    auto& actor_storage     = hub.actor_storage();
+    auto& profile_storage   = hub.profile_storage();
+    auto& mechanics_storage = hub.mechanics_storage();
+    auto& geometry_storage  = hub.geometry_storage();
+    auto& transform_storage = hub.model_transform_storage();
+
+    // ================================================================
+    // Phase 1：只读遍历 scene → actor → profile → mechanics → geometry → transform
+    //          将局部 (min_xyz, max_xyz) 通过 ModelTransform 变换到世界 AABB
+    //          收集为 Octree::Entry 列表
+    //
+    //          注意：此阶段只持有 Storage 的 shared_lock(读)，
+    //          避免在下阶段获取 unique_lock(写) 时发生死锁。
+    // ================================================================
+    struct SceneBuildData {
+        std::uintptr_t                                      key;
+        std::vector<Spatial::Octree<Impl::Payload>::Entry> entries;
+        std::size_t                                         actor_count = 0;
+    };
+    std::vector<SceneBuildData> build_list;
+
+    for (const auto& scene : scene_storage) {
+        if (!scene.enabled) continue;
+
+        SceneBuildData bd;
+        bd.key         = reinterpret_cast<std::uintptr_t>(&scene);
+        bd.actor_count = scene.actor_handles.size();
+        bd.entries.reserve(scene.actor_handles.size());
+
+        for (auto actor_handle : scene.actor_handles) {
+            auto actor = actor_storage.acquire_read(actor_handle);
+            if (!actor) continue;
+
+            // ActorDevice → ProfileDevice → MechanicsDevice → GeometryDevice → ModelTransform
+            // 一个 actor 可能有多个含 mechanics 的 profile，合并所有 world AABB 为一个条目
+            bool has_any_mech = false;
+            Spatial::AABB actor_world_box{};
+
+            for (auto profile_handle : actor->profile_handles) {
+                auto profile = profile_storage.acquire_read(profile_handle);
+                if (!profile || profile->mechanics_handle == 0) continue;
+
+                auto mech = mechanics_storage.acquire_read(profile->mechanics_handle);
+                if (!mech || !mech->physics_enabled) continue;
+
+                auto geom = geometry_storage.acquire_read(mech->geometry_handle);
+                if (!geom) continue;
+
+                auto tx = transform_storage.acquire_read(geom->transform_handle);
+                if (!tx) continue;
+
+                // 将局部 AABB 的 8 个角点变换到世界空间，取 min/max 包络
+                ktm::fmat4x4 M = tx->compute_matrix();
+                auto to_world = [&M](const ktm::fvec3& local) -> ktm::fvec3 {
+                    ktm::fvec4 h{local.x, local.y, local.z, 1.0f};
+                    ktm::fvec4 w = M * h;
+                    return ktm::fvec3{w.x, w.y, w.z};
+                };
+
+                const ktm::fvec3& lmin = mech->min_xyz;
+                const ktm::fvec3& lmax = mech->max_xyz;
+
+                // 局部 AABB 的 8 个角点：min/max 各分量组合 → 世界空间 → 取包络
+                ktm::fvec3 corners[8] = {
+                    {lmin.x, lmin.y, lmin.z}, {lmax.x, lmin.y, lmin.z},
+                    {lmin.x, lmax.y, lmin.z}, {lmax.x, lmax.y, lmin.z},
+                    {lmin.x, lmin.y, lmax.z}, {lmax.x, lmin.y, lmax.z},
+                    {lmin.x, lmax.y, lmax.z}, {lmax.x, lmax.y, lmax.z},
+                };
+                Spatial::AABB world_box;
+                ktm::fvec3 wp0 = to_world(corners[0]);
+                world_box.min = wp0;
+                world_box.max = wp0;
+                for (int i = 1; i < 8; ++i) {
+                    ktm::fvec3 wp = to_world(corners[i]);
+                    world_box.min.x = std::min(world_box.min.x, wp.x);
+                    world_box.min.y = std::min(world_box.min.y, wp.y);
+                    world_box.min.z = std::min(world_box.min.z, wp.z);
+                    world_box.max.x = std::max(world_box.max.x, wp.x);
+                    world_box.max.y = std::max(world_box.max.y, wp.y);
+                    world_box.max.z = std::max(world_box.max.z, wp.z);
+                }
+
+                // 合并当前 profile 的世界 AABB 到 actor 的总包围盒
+                actor_world_box = has_any_mech
+                    ? actor_world_box.merged(world_box)
+                    : world_box;
+                has_any_mech = true;
+            }
+
+            if (has_any_mech) {
+                // payload = actor_handle
+                bd.entries.push_back({actor_handle, actor_world_box});
+            }
+        }
+
+        build_list.push_back(std::move(bd));
+    }
+
+    // ================================================================
+    // Phase 2：写阶段 —— 此时所有读锁已释放，安全获取 unique_lock
+    //          合并世界 AABB 得到 root，重建八叉树，写回 SceneDevice
+    // ================================================================
+    std::unique_lock lock(impl_->mtx);
+
+    for (auto& bd : build_list) {
+        auto& state = impl_->get_or_create(bd.key);
+
+        if (bd.entries.empty()) {
+            state.tree.clear();
+            continue;
+        }
+
+        //合并所有 actor 世界 AABB 得到场景根包围盒
+        Spatial::AABB root = bd.entries[0].bounds;
+        for (std::size_t i = 1; i < bd.entries.size(); ++i) {
+            root = root.merged(bd.entries[i].bounds);
+        }
+        root = root.expanded(state.tree.config().root_padding);
+
+        state.tree.rebuild(root, bd.entries);
+
+        // 写回 SceneDevice
+        if (auto s_w = scene_storage.acquire_write(bd.key)) {
+            s_w->min_world    = root.min;
+            s_w->max_world    = root.max;
+            s_w->center_world = root.center();
+        }
+
+        state.stats.actor_total    = bd.actor_count;
+        state.stats.octree_entries = bd.entries.size();
+    }
 }
 
 void SceneSystem::shutdown() {

--- a/src/systems/scene/scene_system.cpp
+++ b/src/systems/scene/scene_system.cpp
@@ -5,6 +5,7 @@
 #include <corona/systems/scene/scene_system.h>
 
 #include <algorithm>
+#include <cmath>
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
@@ -297,6 +298,29 @@ SceneStats SceneSystem::stats(std::uintptr_t scene) const {
     SceneStats s = it->second.stats;
     s.octree_entries = it->second.tree.size();
     return s;
+}
+
+// ============================================================================
+// LOD 工具
+// ============================================================================
+
+float SceneSystem::compute_screen_ratio(const ktm::fvec3& camera_pos,
+                                        float              camera_fov_deg,
+                                        const ktm::fvec3& world_center,
+                                        float              bounding_radius) {
+    float d = ktm::distance(camera_pos, world_center);
+    if (d < 1e-4f) d = 1e-4f;
+    return bounding_radius / (d * std::tan(ktm::radians(camera_fov_deg) * 0.5f));
+}
+
+int SceneSystem::select_lod_level(float                     screen_ratio,
+                                   const std::vector<float>& thresholds) {
+    for (int i = static_cast<int>(thresholds.size()) - 1; i >= 0; --i) {
+        if (screen_ratio <= thresholds[i]) {
+            return i + 1;
+        }
+    }
+    return 0;
 }
 
 }  // namespace Corona::Systems


### PR DESCRIPTION
将八叉树迁移至SceneSystem，作为场景空间查询基础设施， MechanicsSystem改为消费方，通过query_pairs()获取碰撞候选对。并且在SceneSystem 新增两个 static 方法，用于运行时根据相机位置和物体包围球计算屏幕占比并选择 LOD 等级
（八叉树部分好像欧阳也写了，会有冲突）