### PR TITLE
全局积木预览、回档、物理的锁定部分

### DIFF
--- a/editor/CoronaCore/core/components/mechanics.py
+++ b/editor/CoronaCore/core/components/mechanics.py
@@ -80,6 +80,34 @@ class Mechanics:
         except Exception as e:
             raise RuntimeError(f"Mechanics.get_collision_enabled 失败: {e}") from e
 
+    def set_linear_lock(self, lock_x: bool, lock_y: bool, lock_z: bool):
+        """设置线性运动轴锁定（平移锁定）"""
+        try:
+            self.engine_obj.set_linear_lock(lock_x, lock_y, lock_z)
+        except Exception as e:
+            raise RuntimeError(f"Mechanics.set_linear_lock 失败: {e}") from e
+
+    def get_linear_lock(self):
+        """获取线性运动轴锁定状态，返回 (lock_x, lock_y, lock_z)"""
+        try:
+            return self.engine_obj.get_linear_lock()
+        except Exception as e:
+            raise RuntimeError(f"Mechanics.get_linear_lock 失败: {e}") from e
+
+    def set_angular_lock(self, lock_x: bool, lock_y: bool, lock_z: bool):
+        """设置角度运动轴锁定（旋转锁定）"""
+        try:
+            self.engine_obj.set_angular_lock(lock_x, lock_y, lock_z)
+        except Exception as e:
+            raise RuntimeError(f"Mechanics.set_angular_lock 失败: {e}") from e
+
+    def get_angular_lock(self):
+        """获取角度运动轴锁定状态，返回 (lock_x, lock_y, lock_z)"""
+        try:
+            return self.engine_obj.get_angular_lock()
+        except Exception as e:
+            raise RuntimeError(f"Mechanics.get_angular_lock 失败: {e}") from e
+
     def set_collision_callback(self, callback):
         """
         设置碰撞回调
@@ -103,6 +131,10 @@ class Mechanics:
             result['restitution'] = self.get_restitution()
             result['damping'] = self.get_damping()
             result['physics_enabled'] = self.get_physics_enabled()
+            linear = self.get_linear_lock()
+            result['linear_lock'] = list(linear)
+            angular = self.get_angular_lock()
+            result['angular_lock'] = list(angular)
         except Exception:
             pass
         return result

--- a/editor/CoronaCore/core/entities/actor.py
+++ b/editor/CoronaCore/core/entities/actor.py
@@ -356,6 +356,30 @@ class Actor:
             raise RuntimeError("当前 Actor 没有 Mechanics")
         return self._mechanics.get_physics_enabled()
 
+    def set_linear_lock(self, lock_x: bool, lock_y: bool, lock_z: bool):
+        """设置线性运动轴锁定（锁定后该轴不参与平移运动）"""
+        if not hasattr(self, '_mechanics') or self._mechanics is None:
+            raise RuntimeError("当前 Actor 没有 Mechanics")
+        self._mechanics.set_linear_lock(lock_x, lock_y, lock_z)
+
+    def get_linear_lock(self):
+        """获取线性运动轴锁定状态，返回 [lock_x, lock_y, lock_z]"""
+        if not hasattr(self, '_mechanics') or self._mechanics is None:
+            return [False, False, False]
+        return list(self._mechanics.get_linear_lock())
+
+    def set_angular_lock(self, lock_x: bool, lock_y: bool, lock_z: bool):
+        """设置角度运动轴锁定（锁定后该轴不参与旋转运动）"""
+        if not hasattr(self, '_mechanics') or self._mechanics is None:
+            raise RuntimeError("当前 Actor 没有 Mechanics")
+        self._mechanics.set_angular_lock(lock_x, lock_y, lock_z)
+
+    def get_angular_lock(self):
+        """获取角度运动轴锁定状态，返回 [lock_x, lock_y, lock_z]"""
+        if not hasattr(self, '_mechanics') or self._mechanics is None:
+            return [False, False, False]
+        return list(self._mechanics.get_angular_lock())
+
     def set_collision_enabled(self, collision_type: str):
         """
         设置碰撞检测类型。
@@ -506,6 +530,8 @@ class Actor:
                     "restitution": self.get_restitution(),
                     "damping": self.get_damping(),
                     "physics_enabled": self.get_physics_enabled(),
+                    "linear_lock": self.get_linear_lock(),
+                    "angular_lock": self.get_angular_lock(),
                 }
             except Exception:
                 pass

--- a/editor/CoronaCore/utils/corona_engine_scratch.py
+++ b/editor/CoronaCore/utils/corona_engine_scratch.py
@@ -1,714 +1,675 @@
 # -*- coding: utf-8 -*-
 """
-CoronaEngine Scratch 兼容层
-提供 Scratch 风格的函数式 API，桥接 Blockly 生成的代码与底层 OOP 引擎。
+CoronaEngine Scratch 兼容层。
 
-此模块作为模块级函数使用，生成的 Python 代码以：
+Blockly 生成的代码仍然按旧方式导入本模块：
     from CoronaCore.utils import corona_engine_scratch as CoronaEngine
-方式导入，然后调用 CoronaEngine.move(10) 等。
 
-支持两种模式：
-1. 独立模式（无参数 set_target）：自建内部 Actor（向后兼容）
-2. 绑定模式（调用 set_target）：操作场景管理器中指定的真实 Actor
+运行时状态不再是模块级单例，而是绑定到当前脚本线程的
+ScratchRuntimeContext。这样项目预览可以同时运行项目全局脚本和多个
+Actor 脚本，而不会互相覆盖目标 Actor、变量或输入处理器。
 """
 
-import random as _random
-import time as _time
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 import logging
+import random as _random
 import threading as _threading
+import time as _time
+from typing import Callable, Optional
 
 _logger = logging.getLogger(__name__)
 
-# 线程安全锁：保护对 C++ 引擎对象的访问
 _engine_lock = _threading.Lock()
-
-# ============================================================
-# 内部状态（模块级单例）
-# ============================================================
-
-_x = 0.0
-_y = 0.0
-_z = 0.0
-_rot_x = 0.0
-_rot_y = 0.0
-_rot_z = 0.0
-_size_val = 100.0
-_cartoon_index = 0
-_visible = True
-_variables = {}  # var_name -> float
-
-# 目标 Actor / Scene 引用
-_target_scene_name = None
-_target_actor_name = None
-_target_scene = None
-_target_actor = None
-
-# 底层引擎对象
-_geometry = None
-_optics = None
-_kinematics = None
-_mechanics = None
-_actor = None
-_scene = None
-_initialized = False
-
-# 标记是否已设置外部目标
-_external_target = False
-
-# 脚本执行停止标志（线程安全）
-_stop_requested = False
-
-# 运行计数器（用于诊断"只能运行一次"的问题）
+_context_lock = _threading.RLock()
+_tls = _threading.local()
 _run_count = 0
 
-# 键盘/鼠标事件处理器注册表（由生成的积木代码 register）
-_key_handler = None
-_mouse_handler = None
+
+@dataclass
+class ScratchRuntimeContext:
+    context_id: str
+    target_type: str = "actor"  # actor | project | internal
+    scene_name: str = ""
+    actor_name: str = ""
+
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
+    rot_x: float = 0.0
+    rot_y: float = 0.0
+    rot_z: float = 0.0
+    size_val: float = 100.0
+    cartoon_index: int = 0
+    visible: bool = True
+    variables: dict = field(default_factory=dict)
+
+    target_scene_name: Optional[str] = None
+    target_actor_name: Optional[str] = None
+    target_scene: object = None
+    target_actor: object = None
+
+    geometry: object = None
+    optics: object = None
+    kinematics: object = None
+    mechanics: object = None
+    actor: object = None
+    scene: object = None
+    initialized: bool = False
+    external_target: bool = False
+
+    stop_requested: bool = False
+    key_state: dict = field(default_factory=dict)
+    mouse_pressed: bool = False
+    mouse_x: float = 0.0
+    mouse_y: float = 0.0
+    key_handler: Optional[Callable] = None
+    mouse_handler: Optional[Callable] = None
+
+
+_default_context = ScratchRuntimeContext("default", target_type="internal")
+_contexts: dict[str, ScratchRuntimeContext] = {"default": _default_context}
+
+
+def _current_context() -> ScratchRuntimeContext:
+    ctx = getattr(_tls, "ctx", None)
+    return ctx if ctx is not None else _default_context
+
+
+def create_context(
+    context_id: str | None = None,
+    target_type: str = "actor",
+    scene_name: str = "",
+    actor_name: str = "",
+) -> ScratchRuntimeContext:
+    if not context_id:
+        context_id = f"scratch-{_threading.get_ident()}-{int(_time.time() * 1000)}"
+    ctx = ScratchRuntimeContext(
+        context_id=context_id,
+        target_type=target_type or "actor",
+        scene_name=scene_name or "",
+        actor_name=actor_name or "",
+    )
+    if ctx.target_type == "project":
+        ctx.initialized = True
+    elif ctx.scene_name and ctx.actor_name:
+        ctx.target_scene_name = ctx.scene_name
+        ctx.target_actor_name = ctx.actor_name
+        ctx.external_target = True
+    with _context_lock:
+        _contexts[ctx.context_id] = ctx
+    return ctx
+
+
+def bind_context(ctx: ScratchRuntimeContext):
+    _tls.ctx = ctx
+    with _context_lock:
+        _contexts[ctx.context_id] = ctx
+    return ctx
+
+
+def release_context(ctx: ScratchRuntimeContext | None = None):
+    if ctx is None:
+        ctx = getattr(_tls, "ctx", None)
+    if ctx is not None and ctx.context_id != "default":
+        with _context_lock:
+            _contexts.pop(ctx.context_id, None)
+    if getattr(_tls, "ctx", None) is ctx:
+        _tls.ctx = None
+
+
+@contextmanager
+def using_context(ctx: ScratchRuntimeContext):
+    previous = getattr(_tls, "ctx", None)
+    _tls.ctx = ctx
+    try:
+        yield ctx
+    finally:
+        _tls.ctx = previous
+
+
+def _live_contexts() -> list[ScratchRuntimeContext]:
+    with _context_lock:
+        return [ctx for ctx in _contexts.values() if ctx.context_id != "default"]
 
 
 def register_key_handler(handler):
-    """注册键盘事件处理器"""
-    global _key_handler
-    _key_handler = handler
-    _logger.debug(f"[ScratchWrapper] 键盘处理器已注册: {handler.__name__ if handler else 'None'}")
+    ctx = _current_context()
+    ctx.key_handler = handler
+    _logger.debug("[ScratchWrapper] key handler registered: %s", getattr(handler, "__name__", None))
+
 
 def unregister_key_handler():
-    """取消注册键盘事件处理器"""
-    global _key_handler
-    _key_handler = None
-    _logger.debug("[ScratchWrapper] 键盘处理器已取消注册")
+    _current_context().key_handler = None
 
 
 def register_mouse_handler(handler):
-    """注册鼠标事件处理器"""
-    global _mouse_handler
-    _mouse_handler = handler
+    _current_context().mouse_handler = handler
+
+
+def unregister_mouse_handler():
+    _current_context().mouse_handler = None
 
 
 def handle_key_event(key, mods=None, display_key=None):
-    """分发键盘事件到注册的处理器，同时更新 _key_state"""
     if display_key is None:
         display_key = key
-    # 存储所有可能的形式供 detect 积木匹配
     keys_to_set = {key, display_key}
     if len(display_key) == 1:
         keys_to_set.add(display_key.lower())
         keys_to_set.add(display_key.upper())
-    for k in keys_to_set:
-        _key_state[k] = True
-
-    # 打印当前按键信息，帮助用户确认积木配置
-    # KeyDebug 信息改为 logger.debug，默认静默
-
-    # 调用注册的 handler
-    if _key_handler is None:
-        _logger.warning(f"[ScratchWrapper] 收到按键 {key} 但无注册的 handler！")
-        return
-    try:
-        _key_handler(key, mods or [])
-    except SystemExit:
-        raise
-    except Exception as e:
-        _logger.warning(f"[ScratchWrapper] 键盘事件处理异常: {e}")
+    for ctx in _live_contexts() or [_default_context]:
+        for item in keys_to_set:
+            ctx.key_state[item] = True
+        if ctx.key_handler is None or ctx.stop_requested:
+            continue
+        try:
+            with using_context(ctx):
+                ctx.key_handler(key, mods or [])
+        except SystemExit:
+            ctx.stop_requested = True
+        except Exception as exc:
+            _logger.warning("[ScratchWrapper] key handler error: %s", exc)
 
 
 def handle_key_release(key, display_key=None):
-    """键盘释放事件：同时清除 code 和 key 形式的状态"""
-    _key_state[key] = False
-    if display_key:
-        _key_state[display_key] = False
-        if len(display_key) == 1:
-            _key_state[display_key.lower()] = False
-            _key_state[display_key.upper()] = False
+    for ctx in _live_contexts() or [_default_context]:
+        ctx.key_state[key] = False
+        if display_key:
+            ctx.key_state[display_key] = False
+            if len(display_key) == 1:
+                ctx.key_state[display_key.lower()] = False
+                ctx.key_state[display_key.upper()] = False
 
 
 def handle_mouse_event(event_type, button, x, y):
-    """分发鼠标事件到注册的处理器，同时更新鼠标状态"""
-    global _mouse_pressed, _mouse_x, _mouse_y
-    if event_type in ('click', 'mousedown'):
-        _mouse_pressed = True
-    elif event_type in ('mouseup',):
-        _mouse_pressed = False
-    _mouse_x = float(x)
-    _mouse_y = float(y)
-    # 调用注册的 handler
-    if _mouse_handler is not None:
+    for ctx in _live_contexts() or [_default_context]:
+        if event_type in ("click", "mousedown"):
+            ctx.mouse_pressed = True
+        elif event_type == "mouseup":
+            ctx.mouse_pressed = False
+        ctx.mouse_x = float(x)
+        ctx.mouse_y = float(y)
+        if ctx.mouse_handler is None or ctx.stop_requested:
+            continue
         try:
-            _mouse_handler(event_type, button, x, y)
+            with using_context(ctx):
+                ctx.mouse_handler(event_type, button, x, y)
         except SystemExit:
-            raise
-        except Exception as e:
-            _logger.warning(f"[ScratchWrapper] 鼠标事件处理异常: {e}")
+            ctx.stop_requested = True
+        except Exception as exc:
+            _logger.warning("[ScratchWrapper] mouse handler error: %s", exc)
 
 
 def set_target(scene_name: str, actor_name: str):
-    """设置该模块操作的目标 Actor（绑定到场景中的真实物体）
-    
-    调用此函数后，所有操作将作用于场景管理器中的实际 Actor，
-    而非自建的内部对象。
-    
-    Args:
-        scene_name: 场景路径/名称，如 "Scene/main.scene"
-        actor_name: Actor 名称
-    """
-    global _target_scene_name, _target_actor_name, _external_target, _initialized
-    _target_scene_name = scene_name
-    _target_actor_name = actor_name
-    _external_target = True
-    _initialized = False  # 强制重新初始化
+    ctx = _current_context()
+    ctx.target_type = "actor"
+    ctx.scene_name = scene_name or ""
+    ctx.actor_name = actor_name or ""
+    ctx.target_scene_name = scene_name
+    ctx.target_actor_name = actor_name
+    ctx.external_target = True
+    ctx.initialized = False
     _logger.debug("[ScratchWrapper] set_target: scene=%s actor=%s", scene_name, actor_name)
 
 
+def set_project_global():
+    ctx = _current_context()
+    ctx.target_type = "project"
+    ctx.external_target = False
+    ctx.initialized = True
+
+
+def _actor_only(api_name: str) -> bool:
+    ctx = _current_context()
+    if ctx.target_type == "project":
+        _logger.warning("[ScratchWrapper] %s ignored in project-global script", api_name)
+        return True
+    return False
+
+
 def _init_engine():
-    """延迟初始化底层 CoronaEngine 对象
-    
-    如果已通过 set_target() 绑定了外部 Actor，则从 scene_manager 查找真实对象；
-    否则自建内部 Actor（向后兼容）。
-    """
-    global _geometry, _optics, _kinematics, _actor, _scene, _initialized
-    global _target_scene, _target_actor
-
-    if _initialized:
+    ctx = _current_context()
+    if ctx.initialized:
         return
-    _initialized = True
-
-    if _external_target:
-        _init_external_target()
+    ctx.initialized = True
+    if ctx.target_type == "project":
+        return
+    if ctx.external_target:
+        _init_external_target(ctx)
     else:
-        _init_internal_actor()
+        _init_internal_actor(ctx)
 
 
-def _init_external_target():
-    """绑定到场景管理器中的真实 Actor"""
-    global _geometry, _optics, _kinematics, _actor, _scene
-    global _target_scene, _target_actor
-
-    _logger.debug("[ScratchWrapper] _init_external_target: scene=%s actor=%s",
-                 _target_scene_name, _target_actor_name)
-
+def _init_external_target(ctx: ScratchRuntimeContext):
     try:
         from CoronaCore.core.managers import scene_manager
 
-        _target_scene = scene_manager.get(_target_scene_name)
-        if _target_scene is None:
-            _logger.warning("[ScratchWrapper] 场景未找到，回退独立模式")
-            _init_internal_actor()
+        ctx.target_scene = scene_manager.get(ctx.target_scene_name)
+        if ctx.target_scene is None:
+            _logger.warning("[ScratchWrapper] scene not found, fallback internal: %s", ctx.target_scene_name)
+            _init_internal_actor(ctx)
             return
 
-        _target_actor = _target_scene.find_actor(_target_actor_name)
-        if _target_actor is None:
-            _logger.warning("[ScratchWrapper] Actor未找到，回退独立模式")
-            _init_internal_actor()
+        ctx.target_actor = ctx.target_scene.find_actor(ctx.target_actor_name)
+        if ctx.target_actor is None:
+            _logger.warning("[ScratchWrapper] actor not found, fallback internal: %s", ctx.target_actor_name)
+            _init_internal_actor(ctx)
             return
 
-        _logger.debug("[ScratchWrapper] Actor找到: type=%s id=%s",
-                     type(_target_actor).__name__, id(_target_actor))
-
-        # 获取真实 Actor 的组件
-        _actor = _target_actor
-        _scene = _target_scene
-
-        if hasattr(_target_actor, '_geometry') and _target_actor._geometry is not None:
-            _geometry = _target_actor._geometry
-            _logger.debug("[ScratchWrapper] _geometry绑定: type=%s", type(_geometry).__name__)
-        else:
-            _logger.debug("[ScratchWrapper] _geometry未找到 (hasattr=%s)", hasattr(_target_actor, '_geometry'))
-
-        if hasattr(_target_actor, '_optics') and _target_actor._optics is not None:
-            _optics = _target_actor._optics
-        if hasattr(_target_actor, '_kinematics') and _target_actor._kinematics is not None:
-            _kinematics = _target_actor._kinematics
-
-        if hasattr(_target_actor, '_mechanics') and _target_actor._mechanics is not None:
-            _mechanics = _target_actor._mechanics
-
-        # 同步内部状态到实际 Actor 的当前值
-        try:
-            pos = _target_actor.get_position()
-            global _x, _y, _z
-            _x, _y, _z = float(pos[0]), float(pos[1]), float(pos[2])
-        except Exception:
-            pass
+        ctx.actor = ctx.target_actor
+        ctx.scene = ctx.target_scene
+        ctx.geometry = getattr(ctx.target_actor, "_geometry", None)
+        ctx.optics = getattr(ctx.target_actor, "_optics", None)
+        ctx.kinematics = getattr(ctx.target_actor, "_kinematics", None)
+        ctx.mechanics = getattr(ctx.target_actor, "_mechanics", None)
 
         try:
-            scl = _target_actor.get_scale()
-            global _size_val
-            _size_val = float(scl[0]) * 100.0
+            pos = ctx.target_actor.get_position()
+            ctx.x, ctx.y, ctx.z = float(pos[0]), float(pos[1]), float(pos[2])
         except Exception:
             pass
-
-        # 旋转状态：读取 C++ 当前值并同步到内部状态
-        # 不做 reset-to-zero，因为和后续 rotateX 在同一帧会导致视觉不变
         try:
-            if hasattr(_target_actor, 'get_rotation'):
-                cpp_rot = _target_actor.get_rotation()
-                global _rot_x, _rot_y, _rot_z
-                _rot_x, _rot_y, _rot_z = float(cpp_rot[0]), float(cpp_rot[1]), float(cpp_rot[2])
-                _logger.debug("[ScratchWrapper] 同步C++ rotation=(%.1f,%.1f,%.1f)", _rot_x, _rot_y, _rot_z)
+            rot = ctx.target_actor.get_rotation()
+            ctx.rot_x, ctx.rot_y, ctx.rot_z = float(rot[0]), float(rot[1]), float(rot[2])
         except Exception:
             pass
-
-        _logger.debug(
-            "[ScratchWrapper] 已绑定: scene=%s actor=%s pos=(%.2f,%.2f,%.2f) size=%.1f",
-            _target_scene_name, _target_actor_name, _x, _y, _z, _size_val,
-        )
-    except Exception as e:
-        import traceback
-        traceback.print_exc()
-        _logger.warning("[ScratchWrapper] 绑定外部Actor异常: %s", e)
-        _init_internal_actor()
+        try:
+            scale = ctx.target_actor.get_scale()
+            ctx.size_val = float(scale[0]) * 100.0
+        except Exception:
+            pass
+    except Exception as exc:
+        _logger.exception("[ScratchWrapper] bind actor failed: %s", exc)
+        _init_internal_actor(ctx)
 
 
-def _init_internal_actor():
-    """独立模式（无场景上下文）
-
-    不创建引擎对象（避免加载不存在的模型文件报错），
-    仅使用内部变量 _x/_y/_z/_size_val 追踪状态。
-    所有 getter/setter 函数已对 None 做了安全保护。
-    """
-    global _geometry, _optics, _kinematics, _mechanics, _actor, _scene
-
-    _geometry = None
-    _optics = None
-    _kinematics = None
-    _mechanics = None
-    _actor = None
-    _scene = None
-
-    _logger.debug("[ScratchWrapper] 独立模式（无渲染）")
+def _init_internal_actor(ctx: ScratchRuntimeContext):
+    ctx.geometry = None
+    ctx.optics = None
+    ctx.kinematics = None
+    ctx.mechanics = None
+    ctx.actor = None
+    ctx.scene = None
 
 
-# ============================================================
-# 运动 (Engine) — 16 个函数
-# ============================================================
+def _sync_position():
+    ctx = _current_context()
+    check_stop()
+    with _engine_lock:
+        if ctx.geometry is not None:
+            try:
+                ctx.geometry.set_position([ctx.x, ctx.y, ctx.z])
+                return
+            except Exception as exc:
+                _logger.debug("_sync_position geometry failed: %s", exc)
+        if ctx.actor is not None and hasattr(ctx.actor, "set_position"):
+            try:
+                ctx.actor.set_position([ctx.x, ctx.y, ctx.z])
+            except Exception as exc:
+                _logger.debug("_sync_position actor failed: %s", exc)
 
-def move(steps):
-    """向前移动 steps 步"""
-    _init_engine()
-    global _x
-    old_x = _x
-    _x += float(steps)
-    _logger.debug("[ScratchWrapper] move(%s): X %.1f -> %.1f", steps, old_x, _x)
-    _sync_position()
+
+def _sync_scale():
+    ctx = _current_context()
+    check_stop()
+    scale = ctx.size_val / 100.0
+    with _engine_lock:
+        if ctx.geometry is not None:
+            try:
+                ctx.geometry.set_scale([scale, scale, scale])
+                return
+            except Exception as exc:
+                _logger.debug("_sync_scale geometry failed: %s", exc)
+        if ctx.actor is not None and hasattr(ctx.actor, "set_scale"):
+            try:
+                ctx.actor.set_scale([scale, scale, scale])
+            except Exception as exc:
+                _logger.debug("_sync_scale actor failed: %s", exc)
 
 
 def _apply_rotation():
-    """将内部旋转状态同步到引擎。重力开启时临时暂停物理防止覆盖。"""
+    ctx = _current_context()
     check_stop()
-    rot = [_rot_x, _rot_y, _rot_z]
-    kine_ok = geo_ok = actor_ok = mech_was_enabled = False
+    rot = [ctx.rot_x, ctx.rot_y, ctx.rot_z]
+    mech_was_enabled = False
     with _engine_lock:
-        # 如果物理系统启用，临时暂停防止覆盖手动旋转
-        if _mechanics is not None and hasattr(_mechanics, 'set_physics_enabled'):
+        if ctx.mechanics is not None and hasattr(ctx.mechanics, "set_physics_enabled"):
             try:
-                mech_was_enabled = _mechanics.get_physics_enabled()
+                mech_was_enabled = ctx.mechanics.get_physics_enabled()
                 if mech_was_enabled:
-                    _mechanics.set_physics_enabled(False)
+                    ctx.mechanics.set_physics_enabled(False)
+            except Exception:
+                pass
+        for target, method in (
+            (ctx.kinematics, "set_rotation"),
+            (ctx.geometry, "set_rotation"),
+            (ctx.actor, "set_rotation"),
+        ):
+            if target is not None and hasattr(target, method):
+                try:
+                    getattr(target, method)(rot)
+                except Exception as exc:
+                    _logger.debug("_apply_rotation %s failed: %s", method, exc)
+        if mech_was_enabled and ctx.mechanics is not None:
+            try:
+                ctx.mechanics.set_physics_enabled(True)
             except Exception:
                 pass
 
-        if _kinematics is not None and hasattr(_kinematics, 'set_rotation'):
-            try:
-                _kinematics.set_rotation(rot)
-                kine_ok = True
-            except Exception as e:
-                _logger.debug("[ROT-DIAG] _apply_rotation: kine.set FAILED: %s", e)
-        if _geometry is not None:
-            try:
-                _geometry.set_rotation(rot)
-                geo_ok = True
-            except Exception as e:
-                _logger.debug("[ROT-DIAG] _apply_rotation: geo.set FAILED: %s", e)
-        if _actor is not None and hasattr(_actor, 'set_rotation'):
-            try:
-                _actor.set_rotation(rot)
-                actor_ok = True
-            except Exception as e:
-                _logger.debug("[ROT-DIAG] _apply_rotation: actor.set FAILED: %s", e)
 
-        # 恢复物理
-        if mech_was_enabled and _mechanics is not None:
-            try:
-                _mechanics.set_physics_enabled(True)
-            except Exception:
-                pass
-
-    _logger.debug("[ROT-DIAG] _apply_rotation #%d: rot=%s kine_ok=%s geo_ok=%s actor_ok=%s mech_suspended=%s",
-                 _run_count, rot, kine_ok, geo_ok, actor_ok, mech_was_enabled)
+# Engine / motion
+def move(steps):
+    if _actor_only("move"):
+        return
+    _init_engine()
+    ctx = _current_context()
+    ctx.x += float(steps)
+    _sync_position()
 
 
 def rotateX(angle):
-    """绕X轴旋转"""
+    if _actor_only("rotateX"):
+        return
     _init_engine()
-    global _rot_x
-    _rot_x += float(angle)
-    # 优先 kinematics 增量旋转（物理系统兼容），再同步 geometry（视觉更新）
-    if _kinematics is not None and hasattr(_kinematics, 'rotate_x'):
+    ctx = _current_context()
+    ctx.rot_x += float(angle)
+    if ctx.kinematics is not None and hasattr(ctx.kinematics, "rotate_x"):
         try:
-            _kinematics.rotate_x(float(angle))
+            ctx.kinematics.rotate_x(float(angle))
         except Exception:
             pass
-    # 始终同步 geometry（渲染器读 geometry，不同步则视觉不变）
     _apply_rotation()
-    _logger.debug(f"[ScratchWrapper] rotateX({angle}) -> rot_x={_rot_x:.1f}")
 
 
 def rotateY(angle):
-    """绕Y轴旋转"""
+    if _actor_only("rotateY"):
+        return
     _init_engine()
-    global _rot_y
-    _rot_y += float(angle)
-    if _kinematics is not None and hasattr(_kinematics, 'rotate_y'):
+    ctx = _current_context()
+    ctx.rot_y += float(angle)
+    if ctx.kinematics is not None and hasattr(ctx.kinematics, "rotate_y"):
         try:
-            _kinematics.rotate_y(float(angle))
+            ctx.kinematics.rotate_y(float(angle))
         except Exception:
             pass
     _apply_rotation()
-    _logger.debug(f"[ScratchWrapper] rotateY({angle}) -> rot_y={_rot_y:.1f}")
 
 
 def rotateZ(angle):
-    """绕Z轴旋转（2D平面旋转）"""
+    if _actor_only("rotateZ"):
+        return
     _init_engine()
-    global _rot_z
-    old = _rot_z
-    _rot_z += float(angle)
-    has_kine = _kinematics is not None and hasattr(_kinematics, 'rotate_z')
-    has_geo = _geometry is not None
-    _logger.debug("[ROT-DIAG] rotateZ(%s) #%d: _rot_z %.1f->%.1f has_kine=%s has_geo=%s",
-                 angle, _run_count, old, _rot_z, has_kine, has_geo)
-    if has_kine:
+    ctx = _current_context()
+    ctx.rot_z += float(angle)
+    if ctx.kinematics is not None and hasattr(ctx.kinematics, "rotate_z"):
         try:
-            _kinematics.rotate_z(float(angle))
-            _logger.debug("[ROT-DIAG] rotateZ: kinematics.rotate_z OK")
-        except Exception as e:
-            _logger.debug("[ROT-DIAG] rotateZ: kinematics.rotate_z FAILED: %s", e)
+            ctx.kinematics.rotate_z(float(angle))
+        except Exception:
+            pass
     _apply_rotation()
 
 
 def face(direction):
-    """面向某个方向（0=右, 90=前, 180=左, 270=后，设置绝对朝向）"""
+    if _actor_only("face"):
+        return
     _init_engine()
-    global _rot_y
-    _rot_y = float(direction)
+    _current_context().rot_y = float(direction)
     _apply_rotation()
 
 
 def rotationX():
-    """获取当前X轴旋转角度"""
     _init_engine()
-    return _rot_x
+    return _current_context().rot_x
 
 
 def rotationY():
-    """获取当前Y轴旋转角度"""
     _init_engine()
-    return _rot_y
+    return _current_context().rot_y
 
 
 def rotationZ():
-    """获取当前Z轴旋转角度"""
     _init_engine()
-    return _rot_z
+    return _current_context().rot_z
 
 
 def moveto(position):
-    """移动到预设位置"""
-    _init_engine()
-    global _x, _y, _z
-
-    import random
-
-    if position == 'random_position':
-        _x = random.uniform(-10, 10)
-        _y = random.uniform(-5, 5)
-        _z = random.uniform(-10, 10)
-    elif position == 'sight_position':
-        _x, _y, _z = 0.0, 0.0, 0.0
-    else:
-        _logger.debug("[ScratchWrapper] moveto 未知位置: %s", position)
+    if _actor_only("moveto"):
         return
-
+    _init_engine()
+    ctx = _current_context()
+    if position == "random_position":
+        ctx.x = _random.uniform(-10, 10)
+        ctx.y = _random.uniform(-5, 5)
+        ctx.z = _random.uniform(-10, 10)
+    elif position == "sight_position":
+        ctx.x, ctx.y, ctx.z = 0.0, 0.0, 0.0
+    else:
+        _logger.warning("[ScratchWrapper] unknown moveto position: %s", position)
+        return
     _sync_position()
-    _logger.debug("[ScratchWrapper] moveto(%s) -> (%.2f, %.2f, %.2f)", position, _x, _y, _z)
 
 
 def movetoXYZ(position):
-    """移动到 XYZ 位置"""
-    _init_engine()
-    _logger.debug(f"[ScratchWrapper] movetoXYZ({position})")
+    _logger.debug("[ScratchWrapper] movetoXYZ(%s)", position)
 
 
 def movetoXYZtime(t, x1, x2, x3):
-    """在 t 时间内移动到 (x1,x2,x3)"""
+    if _actor_only("movetoXYZtime"):
+        return
     _init_engine()
-    global _x, _y, _z
-    _x, _y, _z = float(x1), float(x2), float(x3)
+    ctx = _current_context()
+    ctx.x, ctx.y, ctx.z = float(x1), float(x2), float(x3)
     _sync_position()
-    _logger.debug(f"[ScratchWrapper] movetoXYZtime(t={t}, x={x1},{x2},{x3})")
 
 
 def Xset(x):
-    """设置 X 坐标"""
+    if _actor_only("Xset"):
+        return
     _init_engine()
-    global _x
-    _x = float(x)
+    _current_context().x = float(x)
     _sync_position()
 
 
 def Yset(y):
-    """设置 Y 坐标"""
+    if _actor_only("Yset"):
+        return
     _init_engine()
-    global _y
-    _y = float(y)
+    _current_context().y = float(y)
     _sync_position()
 
 
 def Zset(z):
-    """设置 Z 坐标"""
+    if _actor_only("Zset"):
+        return
     _init_engine()
-    global _z
-    _z = float(z)
+    _current_context().z = float(z)
     _sync_position()
 
 
 def Xadd(dx):
-    """X 坐标增加"""
+    if _actor_only("Xadd"):
+        return
     _init_engine()
-    global _x
-    _x += float(dx)
+    _current_context().x += float(dx)
     _sync_position()
 
 
 def Yadd(dy):
-    """Y 坐标增加"""
+    if _actor_only("Yadd"):
+        return
     _init_engine()
-    global _y
-    _y += float(dy)
+    _current_context().y += float(dy)
     _sync_position()
 
 
 def Zadd(dz):
-    """Z 坐标增加"""
+    if _actor_only("Zadd"):
+        return
     _init_engine()
-    global _z
-    _z += float(dz)
+    _current_context().z += float(dz)
     _sync_position()
 
 
 def X():
-    """获取 X 坐标"""
     _init_engine()
-    return _x
+    return _current_context().x
 
 
 def Y():
-    """获取 Y 坐标"""
     _init_engine()
-    return _y
+    return _current_context().y
 
 
 def Z():
-    """获取 Z 坐标"""
     _init_engine()
-    return _z
+    return _current_context().z
 
 
-def _sync_position():
-    """将内部坐标同步到引擎 Geometry"""
-    check_stop()  # 旧代码无 check_stop 时，这里兜底检查
-    with _engine_lock:
-        if _geometry is not None:
-            try:
-                _geometry.set_position([_x, _y, _z])
-                return
-            except Exception as e:
-                _logger.debug(f"_sync_position FAILED: {e}")
-        if _actor is not None and hasattr(_actor, 'set_position'):
-            try:
-                _actor.set_position([_x, _y, _z])
-                return
-            except Exception as e:
-                _logger.debug(f"_sync_position(actor) FAILED: {e}")
-
-
-# ============================================================
-# 外观 (Appearance) — 11 个函数
-# ============================================================
-
+# Appearance
 def cartoonSet(index):
-    """切换到指定动画"""
+    if _actor_only("cartoonSet"):
+        return
     _init_engine()
-    global _cartoon_index
-    _cartoon_index = int(index)
-    if _kinematics is not None:
+    ctx = _current_context()
+    ctx.cartoon_index = int(index)
+    if ctx.kinematics is not None:
         try:
-            _kinematics.set_animation(int(index))
+            ctx.kinematics.set_animation(ctx.cartoon_index)
         except Exception:
             pass
 
 
 def nextCartoon():
-    """切换到下一个动画"""
+    if _actor_only("nextCartoon"):
+        return
     _init_engine()
-    global _cartoon_index
-    _cartoon_index += 1
-    if _kinematics is not None:
+    ctx = _current_context()
+    ctx.cartoon_index += 1
+    if ctx.kinematics is not None:
         try:
-            _kinematics.set_animation(_cartoon_index)
+            ctx.kinematics.set_animation(ctx.cartoon_index)
         except Exception:
             pass
 
 
 def playCartoon():
-    """播放动画"""
+    if _actor_only("playCartoon"):
+        return
     _init_engine()
-    if _kinematics is not None:
+    ctx = _current_context()
+    if ctx.kinematics is not None:
         try:
-            _kinematics.play_animation()
+            ctx.kinematics.play_animation()
         except Exception:
             pass
 
 
 def stopCartoon():
-    """停止动画"""
+    if _actor_only("stopCartoon"):
+        return
     _init_engine()
-    if _kinematics is not None:
+    ctx = _current_context()
+    if ctx.kinematics is not None:
         try:
-            _kinematics.stop_animation()
+            ctx.kinematics.stop_animation()
         except Exception:
             pass
 
 
 def resetCartoon():
-    """重置动画"""
+    if _actor_only("resetCartoon"):
+        return
     _init_engine()
-    global _cartoon_index
-    _cartoon_index = 0
-    if _kinematics is not None:
+    ctx = _current_context()
+    ctx.cartoon_index = 0
+    if ctx.kinematics is not None:
         try:
-            _kinematics.set_animation(0)
+            ctx.kinematics.set_animation(0)
         except Exception:
             pass
 
 
 def sizeAdd(ds):
-    """大小增加"""
+    if _actor_only("sizeAdd"):
+        return
     _init_engine()
-    global _size_val
-    _size_val += float(ds)
+    _current_context().size_val += float(ds)
     _sync_scale()
 
 
 def sizeSet(sz):
-    """设置大小"""
+    if _actor_only("sizeSet"):
+        return
     _init_engine()
-    global _size_val
-    _size_val = float(sz)
+    _current_context().size_val = float(sz)
     _sync_scale()
 
 
 def show(v=None):
-    """显示"""
+    if _actor_only("show"):
+        return
     _init_engine()
-    global _visible
-    _visible = True
-    if _optics is not None:
-        try:
-            _optics.set_visible(True)
-        except Exception:
-            pass
-    elif _actor is not None and hasattr(_actor, 'set_visible'):
-        try:
-            _actor.set_visible(True)
-        except Exception:
-            pass
+    ctx = _current_context()
+    ctx.visible = True
+    for target in (ctx.optics, ctx.actor):
+        if target is not None and hasattr(target, "set_visible"):
+            try:
+                target.set_visible(True)
+                return
+            except Exception:
+                pass
 
 
 def hide(v=None):
-    """隐藏"""
+    if _actor_only("hide"):
+        return
     _init_engine()
-    global _visible
-    _visible = False
-    if _optics is not None:
-        try:
-            _optics.set_visible(False)
-        except Exception:
-            pass
-    elif _actor is not None and hasattr(_actor, 'set_visible'):
-        try:
-            _actor.set_visible(False)
-        except Exception:
-            pass
+    ctx = _current_context()
+    ctx.visible = False
+    for target in (ctx.optics, ctx.actor):
+        if target is not None and hasattr(target, "set_visible"):
+            try:
+                target.set_visible(False)
+                return
+            except Exception:
+                pass
 
 
 def cartoon():
-    """获取当前动画编号"""
     _init_engine()
-    return _cartoon_index
+    return _current_context().cartoon_index
 
 
 def size():
-    """获取当前大小"""
     _init_engine()
-    return _size_val
+    return _current_context().size_val
 
 
-def _sync_scale():
-    s = _size_val / 100.0
-    check_stop()  # 旧代码无 check_stop 时，这里兜底检查
-    with _engine_lock:
-        if _geometry is not None:
-            try:
-                _geometry.set_scale([s, s, s])
-                return
-            except Exception as e:
-                _logger.debug(f"_sync_scale FAILED: {e}")
-        if _actor is not None and hasattr(_actor, 'set_scale'):
-            try:
-                _actor.set_scale([s, s, s])
-                return
-            except Exception as e:
-                _logger.debug(f"_sync_scale(actor) FAILED: {e}")
-
-
-# ============================================================
-# 侦测 (Detect) — 8 个函数
-# ============================================================
-
-# 全局输入状态（由 CEF 桥接或独立 demo 更新）
-_key_state = {}       # 按键名 → bool (是否按下)
-_mouse_pressed = False
-_mouse_x = 0.0
-_mouse_y = 0.0
-
-
+# Detect
 def update_key_state(key, pressed):
-    """更新按键状态（由外部事件系统调用）"""
-    _key_state[key] = bool(pressed)
+    _current_context().key_state[key] = bool(pressed)
 
 
 def update_mouse_state(pressed, x, y):
-    """更新鼠标状态（由外部事件系统调用）"""
-    global _mouse_pressed, _mouse_x, _mouse_y
-    _mouse_pressed = bool(pressed)
-    _mouse_x = float(x)
-    _mouse_y = float(y)
+    ctx = _current_context()
+    ctx.mouse_pressed = bool(pressed)
+    ctx.mouse_x = float(x)
+    ctx.mouse_y = float(y)
 
 
 def touch(target):
-    """检测是否碰到目标"""
     return False
 
 
 def distance(target):
-    """到目标的距离"""
     return 0.0
 
 
 def ask(question):
-    """询问并等待回答"""
-    _logger.info(f"[ScratchWrapper] ask: {question}")
+    _logger.info("[ScratchWrapper] ask: %s", question)
     try:
         return input(question)
     except (EOFError, OSError):
@@ -716,241 +677,174 @@ def ask(question):
 
 
 def keyboard(key):
-    """检测按键是否按下"""
-    return _key_state.get(key, False)
+    return _current_context().key_state.get(key, False)
 
 
 def keyboard0(key):
-    """检测按键是否未按下"""
-    return not _key_state.get(key, False)
+    return not _current_context().key_state.get(key, False)
 
 
 def mouse1():
-    """检测鼠标是否按下"""
-    return _mouse_pressed
+    return _current_context().mouse_pressed
 
 
 def mouse0():
-    """检测鼠标是否未按下"""
-    return not _mouse_pressed
+    return not _current_context().mouse_pressed
 
 
 def attribute(name):
-    """获取属性值
-    支持: X, Y, Z, SIZE, DIRECTION, NAME, ID
-    """
     _init_engine()
-    if name == 'X':
-        return _x
-    elif name == 'Y':
-        return _y
-    elif name == 'Z':
-        return _z
-    elif name == 'SIZE':
-        return _size_val
-    elif name == 'DIRECTION':
-        return _rot_y
-    elif name == 'ROTX':
-        return _rot_x
-    elif name == 'ROTY':
-        return _rot_y
-    elif name == 'ROTZ':
-        return _rot_z
-    elif name in ('NAME', 'ID'):
-        return _cartoon_index
-    return 0.0
+    ctx = _current_context()
+    values = {
+        "X": ctx.x,
+        "Y": ctx.y,
+        "Z": ctx.z,
+        "SIZE": ctx.size_val,
+        "DIRECTION": ctx.rot_y,
+        "ROTX": ctx.rot_x,
+        "ROTY": ctx.rot_y,
+        "ROTZ": ctx.rot_z,
+        "NAME": ctx.actor_name or ctx.context_id,
+        "ID": ctx.context_id,
+    }
+    return values.get(name, 0.0)
 
 
-# ============================================================
-# 控制 (Control) — 7 个函数
-# ============================================================
-
+# Control
 def check_stop():
-    """检查停止标志，如果已请求停止则抛出 SystemExit"""
-    if _stop_requested:
+    if _current_context().stop_requested:
         raise SystemExit(0)
 
 
 def wait(seconds):
-    """等待指定秒数，每 0.1 秒检查一次停止标志"""
     remaining = float(seconds)
     while remaining > 0:
-        if _stop_requested:
-            raise SystemExit(0)
-        _time.sleep(min(0.1, remaining))
-        remaining -= 0.1
+        check_stop()
+        step = min(0.1, remaining)
+        _time.sleep(step)
+        remaining -= step
 
 
 def stop(option):
-    """停止脚本
-    option 可能值:
-      - 'ALL_SCRIPTS' / 'all' → 停止所有脚本（退出进程）
-      - 'CURRENT_SCRIPT' / 'this' → 停止当前脚本
-      - 'OTHER_SCRIPTS_OF_ACTOR' → 停止该角色的其他脚本（单脚本模式下同 this）
-    """
     if option in ("ALL_SCRIPTS", "all"):
-        import sys
-        sys.exit(0)
+        request_stop_all()
     raise SystemExit(0)
 
 
 def cloneStart():
-    """当作为克隆体启动时"""
     _logger.debug("[ScratchWrapper] cloneStart")
 
 
 def clone(name):
-    """克隆自身"""
-    _logger.debug(f"[ScratchWrapper] clone({name})")
+    _logger.debug("[ScratchWrapper] clone(%s)", name)
 
 
 def deleteClone():
-    """删除此克隆体"""
     _logger.debug("[ScratchWrapper] deleteClone")
 
 
 def setScene(name):
-    """切换场景"""
-    _logger.debug(f"[ScratchWrapper] setScene({name})")
+    _logger.debug("[ScratchWrapper] setScene(%s)", name)
 
 
 def nextScene():
-    """下一个场景"""
     _logger.debug("[ScratchWrapper] nextScene")
 
 
-# ============================================================
-# 事件 (Event) — 4 个函数
-# ============================================================
-
+# Event
 def gameStart():
-    """游戏开始事件标记"""
     _logger.debug("[ScratchWrapper] gameStart")
 
 
 def RB(message):
-    """发送消息（广播）"""
-    _logger.debug(f"[ScratchWrapper] RB: {message}")
+    _logger.debug("[ScratchWrapper] RB: %s", message)
 
 
 def broadcast(message):
-    """广播消息"""
-    _logger.debug(f"[ScratchWrapper] broadcast: {message}")
+    _logger.debug("[ScratchWrapper] broadcast: %s", message)
 
 
 def broadcastWait(message):
-    """广播消息并等待"""
-    _logger.debug(f"[ScratchWrapper] broadcastWait: {message}")
+    _logger.debug("[ScratchWrapper] broadcastWait: %s", message)
 
 
-# ============================================================
-# 数学 (Math)
-# ============================================================
-
+# Math / variables / lists
 def random(a, b):
-    """返回 a 到 b 之间的随机数"""
     return _random.uniform(float(a), float(b))
 
 
-# ============================================================
-# 变量 (Variable)
-# ============================================================
-
 def var_add(name, value):
-    """变量增加"""
-    _variables[name] = _variables.get(name, 0.0) + float(value)
+    ctx = _current_context()
+    ctx.variables[name] = ctx.variables.get(name, 0.0) + float(value)
 
 
 def var_set(name, value):
-    """设置变量值"""
-    _variables[name] = float(value)
+    _current_context().variables[name] = float(value)
 
 
 def var_show(name):
-    """显示变量"""
-    _logger.info(f"[ScratchWrapper] var_show: {name} = {_variables.get(name, 0.0)}")
+    ctx = _current_context()
+    _logger.info("[ScratchWrapper] var_show: %s = %s", name, ctx.variables.get(name, 0.0))
 
 
 def var_hide(name):
-    """隐藏变量"""
-    _logger.debug(f"[ScratchWrapper] var_hide: {name}")
+    _logger.debug("[ScratchWrapper] var_hide: %s", name)
 
-
-# ============================================================
-# 列表 (List)
-# ============================================================
 
 def list_show(name):
-    """显示列表"""
-    _logger.debug(f"[ScratchWrapper] list_show: {name}")
+    _logger.debug("[ScratchWrapper] list_show: %s", name)
 
 
 def list_hide(name):
-    """隐藏列表"""
-    _logger.debug(f"[ScratchWrapper] list_hide: {name}")
+    _logger.debug("[ScratchWrapper] list_hide: %s", name)
 
 
-# ============================================================
-# 脚本停止控制
-# ============================================================
-
+# Stop/reset compatibility
 def reset_state():
-    """重置所有运行时状态（新脚本执行前调用）"""
-    global _x, _y, _z, _rot_x, _rot_y, _rot_z, _size_val, _cartoon_index, _visible
-    global _variables, _initialized, _external_target
-    global _stop_requested, _key_state, _mouse_pressed, _mouse_x, _mouse_y
-    global _target_scene_name, _target_actor_name, _target_scene, _target_actor
-    global _geometry, _optics, _kinematics, _mechanics, _actor, _scene
-    global _key_handler, _mouse_handler
-
-    _x = 0.0
-    _y = 0.0
-    _z = 0.0
-    _rot_x = 0.0
-    _rot_y = 0.0
-    _rot_z = 0.0
-    _size_val = 100.0
-    _cartoon_index = 0
-    _visible = True
-    _variables = {}
-    _initialized = False
-    _external_target = False
-    _stop_requested = False
-    _key_state = {}
-    _mouse_pressed = False
-    _mouse_x = 0.0
-    _mouse_y = 0.0
-    _target_scene_name = None
-    _target_actor_name = None
-    _target_scene = None
-    _target_actor = None
-    _geometry = None
-    _optics = None
-    _kinematics = None
-    _mechanics = None
-    _actor = None
-    _scene = None
-    _key_handler = None
-    _mouse_handler = None
     global _run_count
+    ctx = _current_context()
+    fresh = ScratchRuntimeContext(ctx.context_id, target_type=ctx.target_type)
+    fresh.scene_name = ctx.scene_name
+    fresh.actor_name = ctx.actor_name
+    if fresh.target_type == "actor" and fresh.scene_name and fresh.actor_name:
+        fresh.target_scene_name = fresh.scene_name
+        fresh.target_actor_name = fresh.actor_name
+        fresh.external_target = True
+    if fresh.target_type == "project":
+        fresh.initialized = True
     _run_count += 1
-    _logger.debug("[ROT-DIAG] reset_state #%d: _rot_z=%.1f _initialized=%s _geometry=%s _kinematics=%s",
-                 _run_count, _rot_z, _initialized, _geometry is not None, _kinematics is not None)
+    bind_context(fresh)
 
 
-def request_stop():
-    """请求停止当前正在执行的脚本"""
-    global _stop_requested
-    _stop_requested = True
-    _logger.info("[ScratchWrapper] 停止请求已发送")
+def request_stop(context_id: str | None = None):
+    if context_id:
+        with _context_lock:
+            ctx = _contexts.get(context_id)
+        if ctx is not None:
+            ctx.stop_requested = True
+        return
+
+    ctx = getattr(_tls, "ctx", None)
+    if ctx is not None and ctx.context_id != "default":
+        ctx.stop_requested = True
+        return
+
+    request_stop_all()
+
+
+def request_stop_all():
+    with _context_lock:
+        for ctx in _contexts.values():
+            ctx.stop_requested = True
 
 
 def reset_stop():
-    """重置停止标志（新脚本执行前调用）"""
-    global _stop_requested
-    _stop_requested = False
+    _current_context().stop_requested = False
 
 
 def is_stop_requested():
-    """检查是否已请求停止"""
-    return _stop_requested
+    return _current_context().stop_requested
+
+
+def active_context_count():
+    return len(_live_contexts())

--- a/editor/CoronaCore/utils/proejct_utils.py
+++ b/editor/CoronaCore/utils/proejct_utils.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import threading
 from functools import wraps
-from typing import Callable, Dict
+from typing import Any, Callable, Dict, Tuple
 
 from utils.settings import version
 
@@ -196,7 +196,43 @@ def append_project_scene(ini_path: str, scene_route: str) -> None:
         set_project_scenes(ini_path, scenes)
 
 
-_save_timers: Dict[int, threading.Timer] = {}
+_save_timers: Dict[int, Tuple[threading.Timer, Any]] = {}
+_save_timers_lock = threading.RLock()
+
+
+def flush_pending_auto_saves() -> int:
+    """
+    同步执行所有仍在防抖队列中的 save_data。
+    用于预览快照前，确保磁盘状态已经追上内存状态。
+    """
+    with _save_timers_lock:
+        pending = list(_save_timers.items())
+        _save_timers.clear()
+
+    flushed = 0
+    for _, (timer, target) in pending:
+        timer.cancel()
+        try:
+            if hasattr(target, 'save_data'):
+                target.save_data()
+                flushed += 1
+        except Exception:
+            logger.exception("flush pending auto-save failed")
+    return flushed
+
+
+def cancel_pending_auto_saves() -> int:
+    """
+    取消所有仍在防抖队列中的 save_data。
+    用于预览恢复前，避免运行时状态在恢复后再次写回磁盘。
+    """
+    with _save_timers_lock:
+        pending = list(_save_timers.values())
+        _save_timers.clear()
+
+    for timer, _ in pending:
+        timer.cancel()
+    return len(pending)
 
 
 def auto_save(func: Callable) -> Callable:
@@ -209,9 +245,10 @@ def auto_save(func: Callable) -> Callable:
         result = func(self, *args, **kwargs)
         if result is True and hasattr(self, 'save_data'):
             obj_key = id(self)
-            old = _save_timers.pop(obj_key, None)
+            with _save_timers_lock:
+                old = _save_timers.pop(obj_key, None)
             if old is not None:
-                old.cancel()
+                old[0].cancel()
 
             def _do_save():
                 try:
@@ -219,10 +256,14 @@ def auto_save(func: Callable) -> Callable:
                 except Exception:
                     pass
                 finally:
-                    _save_timers.pop(obj_key, None)
+                    with _save_timers_lock:
+                        current = _save_timers.get(obj_key)
+                        if current and current[0] is timer:
+                            _save_timers.pop(obj_key, None)
 
             timer = threading.Timer(0.5, _do_save)
-            _save_timers[obj_key] = timer
+            with _save_timers_lock:
+                _save_timers[obj_key] = (timer, self)
             timer.start()
         return result
     return wrapper

--- a/editor/Frontend/src/blockly/components/BlocklyWorkspace.vue
+++ b/editor/Frontend/src/blockly/components/BlocklyWorkspace.vue
@@ -121,31 +121,45 @@
 
 <script>
 // ============================================================
-// 模块级持久状态（组件挂载/卸载后保持）
-// 必须放在独立的 <script> 块中（非 setup），否则会被编译到 setup()
-// 函数作用域内，导致每次组件挂载都重新初始化
+// 模块级只保留跨组件注册表。每个 BlocklyWorkspace 的目标、计时器、
+// workspace 状态都必须留在组件实例内，避免多个详情窗口串台。
 // ============================================================
-
-/** 存储每个 actor 的工作区序列化状态 key: "scene_name/actor_name" → state JSON */
-const workspaceStates = new Map();
-
-/** localStorage 键前缀 */
-const LS_WS_PREFIX = '__bl_ws__';
-
-/** 当前已加载的 actor key */
-let loadedActorKey = '';
-
-/** 当前编辑的 Actor 名称（给积木定义 getter 用） */
-let currentActorNameVar = '';
-
-/** 脚本状态轮询定时器 */
-let pollTimer = null;
-
-/** 自动保存防抖定时器 */
-let autoSaveTimer = null;
 
 /** 自动保存间隔（毫秒） */
 const AUTO_SAVE_DELAY = 3000;
+
+const mountedBlocklyWorkspaces = new Set();
+
+function refreshBlocklyGlobalHooks() {
+  if (typeof window === 'undefined') return;
+
+  if (mountedBlocklyWorkspaces.size === 0) {
+    delete window.__coronaBlocklyFlushSave;
+    delete window.__coronaBlocklyReloadAll;
+    delete window.__coronaBlocklyClearCaches;
+    return;
+  }
+
+  window.__coronaBlocklyFlushSave = () => Promise.all(
+    Array.from(mountedBlocklyWorkspaces, (api) => api.flushSave())
+  );
+  window.__coronaBlocklyReloadAll = () => Promise.all(
+    Array.from(mountedBlocklyWorkspaces, (api) => api.reloadFromProject())
+  );
+  window.__coronaBlocklyClearCaches = () => {
+    mountedBlocklyWorkspaces.forEach((api) => api.clearCache());
+  };
+}
+
+function registerBlocklyWorkspace(api) {
+  mountedBlocklyWorkspaces.add(api);
+  refreshBlocklyGlobalHooks();
+}
+
+function unregisterBlocklyWorkspace(api) {
+  mountedBlocklyWorkspaces.delete(api);
+  refreshBlocklyGlobalHooks();
+}
 </script>
 
 <script setup>
@@ -161,7 +175,13 @@ import Search from './Search.vue';
 import Zoom from './Zoom.vue';
 import Trashcan from './Trashcan.vue';
 import { useStore } from '../store/store.js';
-import { currentSceneName, currentActorName, getActorContext, syncActorContextFromStorage } from '../composables/useActorContext.js';
+import {
+  currentSceneName,
+  currentActorName,
+  currentTargetType,
+  getBlockTargetContext,
+  syncActorContextFromStorage,
+} from '../composables/useActorContext.js';
 
 const props = defineProps({
   actorName: { type: String, default: '' },
@@ -199,7 +219,15 @@ let blocksRegistered = false;
 // 保存 store 引用，供 onUnmounted 清理共享状态
 let sharedStore = null;
 
+let loadedActorKey = '';
+let loadedTargetInfo = null;
+let currentActorNameVar = '';
+let pollTimer = null;
+let autoSaveTimer = null;
+let isLoadingWorkspace = false;
+let targetSwitchSeq = 0;
 let pythonGenerator = null;
+let latestBlocklySavePromise = Promise.resolve(true);
 
 // CEF 键盘事件转发：在 OSR 模式下 Blockly FieldTextInput 的 HTML widget
 // 无法接收原生键盘事件，需要在 document 层面拦截并手动转发
@@ -319,6 +347,27 @@ async function updateGeneratedCode() {
   }
 }
 
+function getCurrentTarget() {
+  if (props.embedded) {
+    return {
+      targetType: 'actor',
+      scene: props.sceneName || '',
+      actor: props.actorName || '',
+    };
+  }
+  return getBlockTargetContext();
+}
+
+function getTargetKey(target) {
+  if (target?.targetType === 'project') return 'project/global';
+  return target?.scene && target?.actor ? `${target.scene}/${target.actor}` : '';
+}
+
+function getTargetDisplayName(target) {
+  if (target?.targetType === 'project') return '项目全局积木';
+  return target?.actor ? `${target.actor} [${target.scene || ''}]` : '';
+}
+
 async function handleToggleRun() {
   if (codeRunning.value) {
     // 当前正在执行 → 停止
@@ -339,15 +388,10 @@ async function handleToggleRun() {
     return;
   }
 
-  // 嵌入模式用 props，独立模式用 useActorContext
-  let scene, actor;
-  if (props.embedded) {
-    scene = props.sceneName;
-    actor = props.actorName;
-  } else {
-    ({ scene, actor } = getActorContext());
-  }
-  if (!scene || !actor) {
+  flushAutoSave();
+
+  const target = getCurrentTarget();
+  if (target.targetType === 'actor' && (!target.scene || !target.actor)) {
     alert('请先在场景中选中一个物体，再点击运行。');
     return;
   }
@@ -357,8 +401,9 @@ async function handleToggleRun() {
     const result = await scriptingService.executePythonCode(
       code,
       0,
-      scene,
-      actor,
+      target.scene,
+      target.actor,
+      target.targetType,
     );
     const execResult = result?.data ?? result;
     if (execResult?.status === 'error') {
@@ -434,17 +479,34 @@ const createNewBroadcast = () => {
 // ============================================================
 // 按 Actor 管理工作区状态（Blockly 官方推荐模式）
 function saveCurrentWorkspace() {
-  if (!workspace || !BlocklyLib || !loadedActorKey) return;
+  if (isLoadingWorkspace || !workspace || !BlocklyLib || !loadedActorKey) {
+    latestBlocklySavePromise = Promise.resolve(false);
+    return latestBlocklySavePromise;
+  }
   try {
+    updateGeneratedCode();
     const state = BlocklyLib.serialization.workspaces.save(workspace);
-    workspaceStates.set(loadedActorKey, state);
-    try { localStorage.setItem(LS_WS_PREFIX + loadedActorKey, JSON.stringify(state)); } catch (_) {}
+    const target = loadedTargetInfo || getCurrentTarget();
+    latestBlocklySavePromise = scriptingService.saveBlocklyTarget({
+      target_type: target.targetType,
+      scene_name: target.scene,
+      actor_name: target.actor,
+      workspace: state,
+      code: generatedCode.value || '',
+      enabled: true,
+    }).catch((e) => {
+      console.warn('[Blockly] 保存项目积木镜像失败:', e);
+      return false;
+    });
     const now = new Date();
     const ts = now.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
     autoSaveLabel.value = `已自动保存 ${ts}`;
+    return latestBlocklySavePromise;
   } catch (e) {
     logError('保存工作区状态失败', e);
     autoSaveLabel.value = '保存失败';
+    latestBlocklySavePromise = Promise.resolve(false);
+    return latestBlocklySavePromise;
   }
 }
 
@@ -462,8 +524,8 @@ function flushAutoSave() {
   if (autoSaveTimer) {
     clearTimeout(autoSaveTimer);
     autoSaveTimer = null;
-    saveCurrentWorkspace();
   }
+  return saveCurrentWorkspace();
 }
 
 /** 标记孤立积木：未连接事件积木(Hat)的块变灰 */
@@ -507,62 +569,104 @@ function markOrphanBlocks() {
 
 /** 工作区变更统一回调 */
 function onWorkspaceChange() {
+  if (isLoadingWorkspace) return;
   updateGeneratedCode();
   scheduleAutoSave();
   markOrphanBlocks();
   if (loadedActorKey) autoSaveLabel.value = '未保存的更改...';
 }
 
+async function loadWorkspaceStateFromProject(target) {
+  const result = await scriptingService.loadBlocklyTarget({
+    target_type: target.targetType,
+    scene_name: target.scene,
+    actor_name: target.actor,
+  });
+  const payload = result?.data ?? result;
+  if (payload?.status === 'error') {
+    throw new Error(payload.message || '加载积木失败');
+  }
+  return payload?.workspace && typeof payload.workspace === 'object'
+    ? payload.workspace
+    : {};
+}
+
+function hasSerializedWorkspaceContent(state) {
+  if (!state || typeof state !== 'object') return false;
+  if (Array.isArray(state.blocks?.blocks) && state.blocks.blocks.length > 0) return true;
+  if (Array.isArray(state.variables) && state.variables.length > 0) return true;
+  return Object.keys(state).length > 0 && JSON.stringify(state) !== '{}';
+}
+
+async function loadTargetWorkspace(target, { saveCurrent = true, force = false } = {}) {
+  if (!workspace || !BlocklyLib) return;
+
+  const normalized = target || { targetType: 'actor', scene: '', actor: '' };
+  const newKey = getTargetKey(normalized);
+  if (!force && newKey === loadedActorKey) return;
+  const seq = ++targetSwitchSeq;
+
+  if (saveCurrent && loadedActorKey) {
+    await flushAutoSave();
+  }
+
+  let nextState = {};
+  if (newKey) {
+    try {
+      nextState = await loadWorkspaceStateFromProject(normalized);
+    } catch (e) {
+      logError('加载目标积木失败', e);
+      autoSaveLabel.value = '加载失败';
+    }
+  }
+  if (seq !== targetSwitchSeq) return;
+
+  isLoadingWorkspace = true;
+  try {
+    workspace.clear();
+    if (hasSerializedWorkspaceContent(nextState)) {
+      BlocklyLib.serialization.workspaces.load(nextState, workspace);
+    }
+  } catch (e) {
+    logError('切换工作区失败', e);
+  } finally {
+    isLoadingWorkspace = false;
+  }
+
+  loadedActorKey = newKey;
+  loadedTargetInfo = normalized.targetType === 'project'
+    ? { targetType: 'project', scene: '', actor: '' }
+    : { targetType: 'actor', scene: normalized.scene || '', actor: normalized.actor || '' };
+  currentActorNameVar = loadedTargetInfo.actor || '';
+  editingTarget.value = getTargetDisplayName(loadedTargetInfo);
+  autoSaveLabel.value = newKey ? '已加载' : '';
+  updateGeneratedCode();
+  markOrphanBlocks();
+}
+
 /**
- * 切换到指定 Actor 的工作区状态
+ * 切换到指定积木目标的工作区状态
  * 参考 Blockly 官方序列化 API：
  *   - 保存当前状态 → 清空工作区 → 加载目标状态
  */
+function switchToTarget(target) {
+  return loadTargetWorkspace(target, { saveCurrent: true, force: false });
+}
+
+function reloadCurrentTargetFromProject() {
+  const target = loadedTargetInfo || getCurrentTarget();
+  return loadTargetWorkspace(target, { saveCurrent: false, force: true });
+}
+
+function clearWorkspaceCache() {
+  if (autoSaveTimer) {
+    clearTimeout(autoSaveTimer);
+    autoSaveTimer = null;
+  }
+}
+
 function switchToActor(sceneName, actorName) {
-  if (!workspace || !BlocklyLib) return;
-
-  const newKey = sceneName && actorName ? `${sceneName}/${actorName}` : '';
-  if (newKey === loadedActorKey) return;
-
-  // 1. 保存当前工作区（立即刷新防抖）
-  flushAutoSave();
-
-  // 2. 清空工作区（保留变量等全局数据）
-  try {
-    workspace.clear();
-  } catch (e) {
-    logError('清空工作区失败', e);
-  }
-
-  // 3. 加载目标 Actor 的工作区状态
-  loadedActorKey = newKey;
-  currentActorNameVar = actorName || '';
-
-  if (newKey) {
-    // 优先内存，兜底从 localStorage 恢复
-    let state = workspaceStates.get(newKey);
-    if (!state) {
-      try {
-        const raw = localStorage.getItem(LS_WS_PREFIX + newKey);
-        if (raw) { state = JSON.parse(raw); workspaceStates.set(newKey, state); }
-      } catch (_) {}
-    }
-    if (state) {
-      try {
-        BlocklyLib.serialization.workspaces.load(state, workspace);
-      } catch (e) {
-        logError('加载工作区状态失败', e);
-      }
-    }
-  }
-
-  // 4. 更新标题
-  editingTarget.value = actorName
-    ? `${actorName} [${sceneName || ''}]`
-    : '';
-
-  // 5. 刷新代码预览
-  updateGeneratedCode();
+  return switchToTarget({ targetType: 'actor', scene: sceneName, actor: actorName });
 }
 
 // 嵌入模式监听 props，独立模式监听全局选中
@@ -573,8 +677,8 @@ if (props.embedded) {
   );
 } else {
   watch(
-    [currentSceneName, currentActorName],
-    ([scene, actor]) => { switchToActor(scene, actor); },
+    [currentTargetType, currentSceneName, currentActorName],
+    () => { switchToTarget(getBlockTargetContext()); },
     { immediate: false },
   );
 }
@@ -834,10 +938,11 @@ function showToast(message, type = 'info') {
 
 /** 生成导出文件名（包含 Actor 和场景信息） */
 function getExportFilename() {
-  const { scene, actor } = getActorContext();
-  const scenePart = scene || 'unknown';
-  const actorPart = actor || 'unknown';
+  const target = loadedTargetInfo || getCurrentTarget();
   const ts = new Date().toISOString().slice(0, 10);
+  if (target.targetType === 'project') return `project_global_${ts}.blockly`;
+  const scenePart = target.scene || 'unknown';
+  const actorPart = target.actor || 'unknown';
   return `${actorPart}_${scenePart}_${ts}.blockly`;
 }
 
@@ -1125,35 +1230,30 @@ function handleNewCanvas() {
   flushAutoSave();
 
   // 2. 清除当前 Actor 的持久化状态
-  if (loadedActorKey) {
-    workspaceStates.delete(loadedActorKey);
-    try { localStorage.removeItem(LS_WS_PREFIX + loadedActorKey); } catch (_) {}
-  }
-
   // 3. 清空工作区
+  isLoadingWorkspace = true;
   try {
     workspace.clear();
   } catch (e) {
     logError('清空工作区失败', e);
+  } finally {
+    isLoadingWorkspace = false;
   }
 
   // 4. 立即保存空的 workspace 状态（覆盖旧状态）
-  try {
-    const emptyState = BlocklyLib.serialization.workspaces.save(workspace);
-    if (loadedActorKey) {
-      workspaceStates.set(loadedActorKey, emptyState);
-    }
-  } catch (e) {
-    logError('保存空状态失败', e);
-  }
-
-  // 5. 刷新代码预览
   updateGeneratedCode();
+  saveCurrentWorkspace();
 }
 
 const handleWindowResize = () => resizeBlockly();
 
 let resizeObserver = null;
+
+const blocklyWorkspaceApi = {
+  flushSave: () => flushAutoSave(),
+  reloadFromProject: () => reloadCurrentTargetFromProject(),
+  clearCache: () => clearWorkspaceCache(),
+};
 
 onMounted(async () => {
   window.addEventListener('resize', handleWindowResize);
@@ -1167,11 +1267,12 @@ onMounted(async () => {
   try {
     await initBlockly();
     if (props.embedded) {
-      switchToActor(props.sceneName, props.actorName);
+      await switchToActor(props.sceneName, props.actorName);
     } else {
       syncActorContextFromStorage();
-      switchToActor(currentSceneName.value, currentActorName.value);
+      await switchToTarget(getBlockTargetContext());
     }
+    registerBlocklyWorkspace(blocklyWorkspaceApi);
   } catch (err) {
     logError('初始化失败', err);
     const overlay = document.getElementById('status-overlay');
@@ -1194,6 +1295,7 @@ onUnmounted(() => {
   teardownScriptKeyForwarding();
   // 清理状态轮询
   clearPollTimer();
+  unregisterBlocklyWorkspace(blocklyWorkspaceApi);
   // 清理自动保存定时器
   if (autoSaveTimer) { clearTimeout(autoSaveTimer); autoSaveTimer = null; }
   // 清理提示定时器

--- a/editor/Frontend/src/blockly/composables/useActorContext.js
+++ b/editor/Frontend/src/blockly/composables/useActorContext.js
@@ -10,12 +10,16 @@ import { ref } from 'vue';
 
 const STORAGE_KEY_SCENE = '__bl_actor_ctx_scene__';
 const STORAGE_KEY_ACTOR = '__bl_actor_ctx_actor__';
+const STORAGE_KEY_TARGET_TYPE = '__bl_target_type__';
 
 /** 当前选中的场景名称 */
 export const currentSceneName = ref(localStorage.getItem(STORAGE_KEY_SCENE) || '');
 
 /** 当前选中的 Actor 名称 */
 export const currentActorName = ref(localStorage.getItem(STORAGE_KEY_ACTOR) || '');
+
+/** 当前积木目标类型：actor | project */
+export const currentTargetType = ref(localStorage.getItem(STORAGE_KEY_TARGET_TYPE) || 'actor');
 
 /**
  * 设置当前目标 Actor。
@@ -24,18 +28,34 @@ export const currentActorName = ref(localStorage.getItem(STORAGE_KEY_ACTOR) || '
 export function setActorContext(sceneName, actorName) {
   const s = sceneName || '';
   const a = actorName || '';
+  currentTargetType.value = 'actor';
   currentSceneName.value = s;
   currentActorName.value = a;
+  localStorage.setItem(STORAGE_KEY_TARGET_TYPE, 'actor');
   localStorage.setItem(STORAGE_KEY_SCENE, s);
   localStorage.setItem(STORAGE_KEY_ACTOR, a);
+}
+
+/**
+ * 切换到项目级全局积木目标。
+ */
+export function setProjectGlobalContext() {
+  currentTargetType.value = 'project';
+  currentSceneName.value = '';
+  currentActorName.value = '';
+  localStorage.setItem(STORAGE_KEY_TARGET_TYPE, 'project');
+  localStorage.removeItem(STORAGE_KEY_SCENE);
+  localStorage.removeItem(STORAGE_KEY_ACTOR);
 }
 
 /**
  * 清除 Actor 上下文。
  */
 export function clearActorContext() {
+  currentTargetType.value = 'actor';
   currentSceneName.value = '';
   currentActorName.value = '';
+  localStorage.setItem(STORAGE_KEY_TARGET_TYPE, 'actor');
   localStorage.removeItem(STORAGE_KEY_SCENE);
   localStorage.removeItem(STORAGE_KEY_ACTOR);
 }
@@ -45,6 +65,7 @@ export function clearActorContext() {
  * 用于 BlocklyWorkspace 等跨标签页实例在挂载或运行前拉取最新状态。
  */
 export function syncActorContextFromStorage() {
+  currentTargetType.value = localStorage.getItem(STORAGE_KEY_TARGET_TYPE) || 'actor';
   currentSceneName.value = localStorage.getItem(STORAGE_KEY_SCENE) || '';
   currentActorName.value = localStorage.getItem(STORAGE_KEY_ACTOR) || '';
 }
@@ -59,4 +80,17 @@ export function getActorContext() {
   const actor =
     currentActorName.value || localStorage.getItem(STORAGE_KEY_ACTOR) || '';
   return { scene, actor };
+}
+
+/**
+ * 获取当前积木目标。项目全局目标不携带 scene/actor。
+ */
+export function getBlockTargetContext() {
+  const targetType =
+    currentTargetType.value || localStorage.getItem(STORAGE_KEY_TARGET_TYPE) || 'actor';
+  if (targetType === 'project') {
+    return { targetType: 'project', scene: '', actor: '' };
+  }
+  const { scene, actor } = getActorContext();
+  return { targetType: 'actor', scene, actor };
 }

--- a/editor/Frontend/src/utils/bridge.js
+++ b/editor/Frontend/src/utils/bridge.js
@@ -231,13 +231,29 @@ export const scriptingService = {
    * @param {string} sceneName - 目标场景名称（可选）
    * @param {string} actorName - 目标 Actor 名称（可选）
    */
-  executePythonCode: (code, mode, sceneName, actorName) =>
+  executePythonCode: (code, mode, sceneName, actorName, targetType = 'actor') =>
     Bridge.callCEF('ScratchTool', 'execute_python_code', [
       code,
       mode ?? 0,
       sceneName ?? '',
       actorName ?? '',
+      targetType || 'actor',
     ]),
+
+  saveBlocklyTarget: (payload) =>
+    Bridge.callCEF('ScratchTool', 'save_blockly_target', [payload || {}]),
+
+  loadBlocklyTarget: (payload) =>
+    Bridge.callCEF('ScratchTool', 'load_blockly_target', [payload || {}]),
+
+  startGamePreview: (payload = { scope: 'project' }) =>
+    Bridge.callCEF('ScratchTool', 'start_game_preview', [payload]),
+
+  stopGamePreview: () =>
+    Bridge.callCEF('ScratchTool', 'stop_game_preview', []),
+
+  getGamePreviewStatus: () =>
+    Bridge.callCEF('ScratchTool', 'get_game_preview_status', []),
 
   /**
    * 停止当前正在执行的脚本

--- a/editor/Frontend/src/views/layout/MainPage.vue
+++ b/editor/Frontend/src/views/layout/MainPage.vue
@@ -258,6 +258,34 @@
           </div>
         </div>
       </div>
+
+      <div class="ml-auto flex items-center gap-2">
+        <button
+          class="px-2.5 py-1 rounded border transition-colors duration-200 whitespace-nowrap"
+          :class="previewRunning || previewBusy
+            ? 'border-gray-600 text-gray-500 bg-[#252525] cursor-not-allowed'
+            : 'border-green-500/50 text-green-200 bg-green-700/20 hover:bg-green-600/30'"
+          :disabled="previewRunning || previewBusy"
+          title="开始项目预览"
+          @click="handleStartGamePreview"
+        >
+          开始预览
+        </button>
+        <button
+          class="px-2.5 py-1 rounded border transition-colors duration-200 whitespace-nowrap"
+          :class="!previewRunning || previewBusy
+            ? 'border-gray-600 text-gray-500 bg-[#252525] cursor-not-allowed'
+            : 'border-red-500/50 text-red-200 bg-red-700/20 hover:bg-red-600/30'"
+          :disabled="!previewRunning || previewBusy"
+          title="结束项目预览"
+          @click="handleStopGamePreview"
+        >
+          结束预览
+        </button>
+        <span v-if="previewStatusText" class="text-xs text-[#b8c7b0] whitespace-nowrap">
+          {{ previewStatusText }}
+        </span>
+      </div>
     </div>
 
     <!-- 场景栏 -->
@@ -441,7 +469,7 @@
 import { computed, ref, onMounted, onUnmounted, reactive, watch, nextTick } from 'vue';
 import { useRouter } from 'vue-router';
 import { DEFAULT_SCENE_NAME } from '@/utils/constants.js';
-import { Bridge, appService, sceneService, projectService } from '@/utils/bridge.js';
+import { Bridge, appService, sceneService, projectService, scriptingService } from '@/utils/bridge.js';
 import { useErrorHandler } from '@/composables/useErrorHandler.js';
 import { useDockStore } from '@/stores/dockStore.js';
 import { PLUGIN_MANIFEST } from '@/config/pluginManifest.js';
@@ -523,6 +551,10 @@ const inputState = reactive({
 
 // 新增：菜单状态
 const activeMenu = ref(null);
+const previewRunning = ref(false);
+const previewBusy = ref(false);
+const previewStatusText = ref('');
+let previewPollTimer = null;
 
 // 物理参数状态
 const physicsParams = ref({
@@ -1308,6 +1340,108 @@ const toggleViewTool = (tool) => {
   dockStore.togglePanel(tool.id);
 };
 
+const unwrapBridgeData = (result) => result?.data ?? result;
+
+const clearPreviewPoll = () => {
+  if (previewPollTimer) {
+    clearTimeout(previewPollTimer);
+    previewPollTimer = null;
+  }
+};
+
+const pollGamePreviewStatus = () => {
+  clearPreviewPoll();
+  const poll = async () => {
+    try {
+      const result = await scriptingService.getGamePreviewStatus();
+      const status = unwrapBridgeData(result);
+      const state = status?.status || 'idle';
+      const count = status?.running_count || 0;
+      const hasSnapshot = !!status?.has_snapshot;
+      previewRunning.value = state === 'running' || state === 'stopping' || count > 0 || hasSnapshot;
+      previewStatusText.value = previewRunning.value
+        ? (count > 0 ? `预览中 ${count}` : '预览已停止，等待恢复')
+        : state === 'error'
+          ? '预览出错'
+          : '';
+      if (previewRunning.value) {
+        previewPollTimer = setTimeout(poll, 1000);
+      }
+    } catch (error) {
+      previewRunning.value = false;
+      previewStatusText.value = '预览状态异常';
+      logError('查询预览状态失败', error);
+    }
+  };
+  previewPollTimer = setTimeout(poll, 800);
+};
+
+const handleStartGamePreview = async () => {
+  if (previewRunning.value || previewBusy.value) return;
+  previewBusy.value = true;
+  previewStatusText.value = '准备预览...';
+  try {
+    if (typeof window.__coronaBlocklyFlushSave === 'function') {
+      await window.__coronaBlocklyFlushSave();
+    }
+    const result = await scriptingService.startGamePreview({ scope: 'project' });
+    const payload = unwrapBridgeData(result);
+    if (payload?.status === 'error') {
+      previewRunning.value = false;
+      previewStatusText.value = '预览启动失败';
+      logError('开始预览失败', payload.message);
+      return;
+    }
+    previewRunning.value = payload?.status === 'running' || (payload?.started_count || 0) > 0;
+    previewStatusText.value = previewRunning.value
+      ? `预览中 ${payload?.started_count || 0}`
+      : '没有可运行积木';
+    if (previewRunning.value) pollGamePreviewStatus();
+  } catch (error) {
+    previewRunning.value = false;
+    previewStatusText.value = '预览启动失败';
+    logError('开始预览失败', error);
+  } finally {
+    previewBusy.value = false;
+    activeMenu.value = null;
+  }
+};
+
+const handleStopGamePreview = async () => {
+  if (!previewRunning.value || previewBusy.value) return;
+  previewBusy.value = true;
+  previewStatusText.value = '正在恢复预览前参数...';
+  let keepPreviewActive = false;
+  try {
+    const result = await scriptingService.stopGamePreview();
+    const payload = unwrapBridgeData(result);
+    if (payload?.restore_error) {
+      keepPreviewActive = true;
+      previewStatusText.value = '预览恢复失败';
+      logError('结束预览恢复失败', payload.restore_error);
+      return;
+    }
+    if (payload?.restored) {
+      previewStatusText.value = '已恢复预览前参数';
+      setTimeout(() => {
+        if (!previewRunning.value && !previewBusy.value && previewStatusText.value === '已恢复预览前参数') {
+          previewStatusText.value = '';
+        }
+      }, 2000);
+    } else {
+      previewStatusText.value = '';
+    }
+  } catch (error) {
+    previewStatusText.value = '结束预览失败';
+    logError('结束预览失败', error);
+  } finally {
+    clearPreviewPoll();
+    previewRunning.value = keepPreviewActive;
+    previewBusy.value = false;
+    activeMenu.value = null;
+  }
+};
+
 // 修改：运行菜单的处理函数
 const handleRunProject = async () => {
   try {
@@ -1501,6 +1635,7 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  clearPreviewPoll();
   stopStageHints();
   coronaEventBus.off('scene-add');
   coronaEventBus.off('scene-rename');

--- a/editor/Frontend/src/views/sidebar/Object.vue
+++ b/editor/Frontend/src/views/sidebar/Object.vue
@@ -633,6 +633,60 @@
                       />
                     </div>
                   </div>
+                  <!-- 轴锁定 - 平移 -->
+                  <div class="mt-2 pt-1 border-t border-[#1a1a1a]/50">
+                    <div class="text-[#909090] text-[10px] mb-1">平移锁定</div>
+                    <div class="grid grid-cols-3 gap-1">
+                      <div class="flex items-center gap-1">
+                        <label class="text-red-400 text-[10px] w-3">X</label>
+                        <input type="checkbox"
+                          v-model="actorData.mechanics.linear_lock[0]"
+                          class="rounded bg-[#1a1a1a] border-[#3c3c3c] checked:bg-red-500 w-3 h-3"
+                          @change="() => { updateLinearLockFast(); updateActorMechanics('SetLinearLock'); }" />
+                      </div>
+                      <div class="flex items-center gap-1">
+                        <label class="text-blue-400 text-[10px] w-3">Y</label>
+                        <input type="checkbox"
+                          v-model="actorData.mechanics.linear_lock[1]"
+                          class="rounded bg-[#1a1a1a] border-[#3c3c3c] checked:bg-blue-500 w-3 h-3"
+                          @change="() => { updateLinearLockFast(); updateActorMechanics('SetLinearLock'); }" />
+                      </div>
+                      <div class="flex items-center gap-1">
+                        <label class="text-green-400 text-[10px] w-3">Z</label>
+                        <input type="checkbox"
+                          v-model="actorData.mechanics.linear_lock[2]"
+                          class="rounded bg-[#1a1a1a] border-[#3c3c3c] checked:bg-green-500 w-3 h-3"
+                          @change="() => { updateLinearLockFast(); updateActorMechanics('SetLinearLock'); }" />
+                      </div>
+                    </div>
+                  </div>
+                  <!-- 轴锁定 - 旋转 -->
+                  <div class="mt-1">
+                    <div class="text-[#909090] text-[10px] mb-1">旋转锁定</div>
+                    <div class="grid grid-cols-3 gap-1">
+                      <div class="flex items-center gap-1">
+                        <label class="text-red-400 text-[10px] w-3">X</label>
+                        <input type="checkbox"
+                          v-model="actorData.mechanics.angular_lock[0]"
+                          class="rounded bg-[#1a1a1a] border-[#3c3c3c] checked:bg-red-500 w-3 h-3"
+                          @change="() => { updateAngularLockFast(); updateActorMechanics('SetAngularLock'); }" />
+                      </div>
+                      <div class="flex items-center gap-1">
+                        <label class="text-blue-400 text-[10px] w-3">Y</label>
+                        <input type="checkbox"
+                          v-model="actorData.mechanics.angular_lock[1]"
+                          class="rounded bg-[#1a1a1a] border-[#3c3c3c] checked:bg-blue-500 w-3 h-3"
+                          @change="() => { updateAngularLockFast(); updateActorMechanics('SetAngularLock'); }" />
+                      </div>
+                      <div class="flex items-center gap-1">
+                        <label class="text-green-400 text-[10px] w-3">Z</label>
+                        <input type="checkbox"
+                          v-model="actorData.mechanics.angular_lock[2]"
+                          class="rounded bg-[#1a1a1a] border-[#3c3c3c] checked:bg-green-500 w-3 h-3"
+                          @change="() => { updateAngularLockFast(); updateActorMechanics('SetAngularLock'); }" />
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </template>
 
@@ -1101,6 +1155,60 @@
                     />
                   </div>
                 </div>
+                <!-- 轴锁定 - 平移 -->
+                <div class="mt-2 pt-1 border-t border-[#1a1a1a]/50">
+                  <div class="text-[#909090] text-[10px] mb-1">平移锁定</div>
+                  <div class="grid grid-cols-3 gap-1">
+                    <div class="flex items-center gap-1">
+                      <label class="text-red-400 text-[10px] w-3">X</label>
+                      <input type="checkbox"
+                        v-model="modelData.mechanics.linear_lock[0]"
+                        class="rounded bg-[#1a1a1a] border-[#3c3c3c] checked:bg-red-500 w-3 h-3"
+                        @change="() => { updateModelLinearLockFast(); updateModelMechanics('SetLinearLock'); }" />
+                    </div>
+                    <div class="flex items-center gap-1">
+                      <label class="text-blue-400 text-[10px] w-3">Y</label>
+                      <input type="checkbox"
+                        v-model="modelData.mechanics.linear_lock[1]"
+                        class="rounded bg-[#1a1a1a] border-[#3c3c3c] checked:bg-blue-500 w-3 h-3"
+                        @change="() => { updateModelLinearLockFast(); updateModelMechanics('SetLinearLock'); }" />
+                    </div>
+                    <div class="flex items-center gap-1">
+                      <label class="text-green-400 text-[10px] w-3">Z</label>
+                      <input type="checkbox"
+                        v-model="modelData.mechanics.linear_lock[2]"
+                        class="rounded bg-[#1a1a1a] border-[#3c3c3c] checked:bg-green-500 w-3 h-3"
+                        @change="() => { updateModelLinearLockFast(); updateModelMechanics('SetLinearLock'); }" />
+                    </div>
+                  </div>
+                </div>
+                <!-- 轴锁定 - 旋转 -->
+                <div class="mt-1">
+                  <div class="text-[#909090] text-[10px] mb-1">旋转锁定</div>
+                  <div class="grid grid-cols-3 gap-1">
+                    <div class="flex items-center gap-1">
+                      <label class="text-red-400 text-[10px] w-3">X</label>
+                      <input type="checkbox"
+                        v-model="modelData.mechanics.angular_lock[0]"
+                        class="rounded bg-[#1a1a1a] border-[#3c3c3c] checked:bg-red-500 w-3 h-3"
+                        @change="() => { updateModelAngularLockFast(); updateModelMechanics('SetAngularLock'); }" />
+                    </div>
+                    <div class="flex items-center gap-1">
+                      <label class="text-blue-400 text-[10px] w-3">Y</label>
+                      <input type="checkbox"
+                        v-model="modelData.mechanics.angular_lock[1]"
+                        class="rounded bg-[#1a1a1a] border-[#3c3c3c] checked:bg-blue-500 w-3 h-3"
+                        @change="() => { updateModelAngularLockFast(); updateModelMechanics('SetAngularLock'); }" />
+                    </div>
+                    <div class="flex items-center gap-1">
+                      <label class="text-green-400 text-[10px] w-3">Z</label>
+                      <input type="checkbox"
+                        v-model="modelData.mechanics.angular_lock[2]"
+                        class="rounded bg-[#1a1a1a] border-[#3c3c3c] checked:bg-green-500 w-3 h-3"
+                        @change="() => { updateModelAngularLockFast(); updateModelMechanics('SetAngularLock'); }" />
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
 
@@ -1490,6 +1598,8 @@ const actorData = ref({
     restitution: 0.8,
     damping: 0.99,
     physics_enabled: true,
+    linear_lock: [false, false, false],
+    angular_lock: [false, false, false],
   },
   script: {
     path: '',
@@ -1520,6 +1630,8 @@ const modelData = ref({
     restitution: 0.8,
     damping: 0.99,
     physics_enabled: true,
+    linear_lock: [false, false, false],
+    angular_lock: [false, false, false],
   },
 });
 
@@ -1652,6 +1764,14 @@ const loadActorData = async (sceneId, actorId) => {
         actorData.value.mechanics.restitution = data.mechanics.restitution ?? 0.8;
         actorData.value.mechanics.damping = data.mechanics.damping ?? 0.99;
         actorData.value.mechanics.physics_enabled = data.mechanics.physics_enabled ?? true;
+        if (data.mechanics.linear_lock !== undefined) {
+          const ll = data.mechanics.linear_lock;
+          actorData.value.mechanics.linear_lock = [Boolean(ll[0]), Boolean(ll[1]), Boolean(ll[2])];
+        }
+        if (data.mechanics.angular_lock !== undefined) {
+          const al = data.mechanics.angular_lock;
+          actorData.value.mechanics.angular_lock = [Boolean(al[0]), Boolean(al[1]), Boolean(al[2])];
+        }
       } else {
         actorData.value.hasMechanics = false;
       }
@@ -1700,6 +1820,14 @@ const loadModelData = async (sceneId, modelId) => {
         modelData.value.mechanics.restitution = data.mechanics.restitution ?? 0.8;
         modelData.value.mechanics.damping = data.mechanics.damping ?? 0.99;
         modelData.value.mechanics.physics_enabled = data.mechanics.physics_enabled ?? true;
+        if (data.mechanics.linear_lock !== undefined) {
+          const ll = data.mechanics.linear_lock;
+          modelData.value.mechanics.linear_lock = [Boolean(ll[0]), Boolean(ll[1]), Boolean(ll[2])];
+        }
+        if (data.mechanics.angular_lock !== undefined) {
+          const al = data.mechanics.angular_lock;
+          modelData.value.mechanics.angular_lock = [Boolean(al[0]), Boolean(al[1]), Boolean(al[2])];
+        }
       }
     }
   } catch (e) {
@@ -1759,6 +1887,8 @@ const PROPERTY = {
   Visible: 3,
   CollisionEnabled: 4,
   PhysicsEnabled: 5,
+  LinearLockMask: 6,
+  AngularLockMask: 7,
 };
 
 const applyAxisOverride = (vector, axis, value) => {
@@ -1936,6 +2066,42 @@ const updateActorMechanicsFast = (propertyType) => {
   try { bridge.setProperty(actorData.value.handle, propertyType, value); } catch (e) { /* ignore */ }
 };
 
+// ── 轴锁定快速通道 ──
+const computeLockMask = (lock_array) =>
+  (lock_array[0] ? 1 : 0) | (lock_array[1] ? 2 : 0) | (lock_array[2] ? 4 : 0);
+
+const updateLinearLockFast = () => {
+  const bridge = window.coronaBridge;
+  if (!bridge || typeof bridge.setProperty !== 'function') return;
+  if (!actorData.value.handle) return;
+  const mask = computeLockMask(actorData.value.mechanics.linear_lock);
+  try { bridge.setProperty(actorData.value.handle, PROPERTY.LinearLockMask, mask); } catch (e) {}
+};
+
+const updateAngularLockFast = () => {
+  const bridge = window.coronaBridge;
+  if (!bridge || typeof bridge.setProperty !== 'function') return;
+  if (!actorData.value.handle) return;
+  const mask = computeLockMask(actorData.value.mechanics.angular_lock);
+  try { bridge.setProperty(actorData.value.handle, PROPERTY.AngularLockMask, mask); } catch (e) {}
+};
+
+const updateModelLinearLockFast = () => {
+  const bridge = window.coronaBridge;
+  if (!bridge || typeof bridge.setProperty !== 'function') return;
+  if (!modelData.value.handle) return;
+  const mask = computeLockMask(modelData.value.mechanics.linear_lock);
+  try { bridge.setProperty(modelData.value.handle, PROPERTY.LinearLockMask, mask); } catch (e) {}
+};
+
+const updateModelAngularLockFast = () => {
+  const bridge = window.coronaBridge;
+  if (!bridge || typeof bridge.setProperty !== 'function') return;
+  if (!modelData.value.handle) return;
+  const mask = computeLockMask(modelData.value.mechanics.angular_lock);
+  try { bridge.setProperty(modelData.value.handle, PROPERTY.AngularLockMask, mask); } catch (e) {}
+};
+
 // 更新单位物理属性 — 慢通道：触发 Python 写盘 + 设置
 const updateActorMechanics = (operationType) => {
   if (!currentActorFile.value || !actorData.value.parentScene) return;
@@ -1955,6 +2121,22 @@ const updateActorMechanics = (operationType) => {
         case 'SetPhysicsEnabled':
           value = actorData.value.mechanics.physics_enabled;
           break;
+        case 'SetLinearLock':
+          await sceneService.actorOperation(
+            actorData.value.parentScene,
+            currentActorFile.value,
+            'SetLinearLock',
+            actorData.value.mechanics.linear_lock.map(v => v ? 1 : 0)
+          );
+          return;
+        case 'SetAngularLock':
+          await sceneService.actorOperation(
+            actorData.value.parentScene,
+            currentActorFile.value,
+            'SetAngularLock',
+            actorData.value.mechanics.angular_lock.map(v => v ? 1 : 0)
+          );
+          return;
         default:
           return;
       }
@@ -2105,6 +2287,22 @@ const updateModelMechanics = (operationType) => {
         case 'SetPhysicsEnabled':
           value = modelData.value.mechanics.physics_enabled;
           break;
+        case 'SetLinearLock':
+          await sceneService.actorOperation(
+            modelData.value.targetScene,
+            currentModelFile.value,
+            'SetLinearLock',
+            modelData.value.mechanics.linear_lock.map(v => v ? 1 : 0)
+          );
+          return;
+        case 'SetAngularLock':
+          await sceneService.actorOperation(
+            modelData.value.targetScene,
+            currentModelFile.value,
+            'SetAngularLock',
+            modelData.value.mechanics.angular_lock.map(v => v ? 1 : 0)
+          );
+          return;
         default:
           return;
       }

--- a/editor/plugins/SceneDatas/main.py
+++ b/editor/plugins/SceneDatas/main.py
@@ -75,6 +75,10 @@ class SceneDatas(PluginBase):
             actor.set_collision_enabled(str(vector[0]))
         elif operation == "SetPhysicsEnabled":
             actor.set_physics_enabled(bool(vector[0]))
+        elif operation == "SetLinearLock":
+            actor.set_linear_lock(bool(vector[0]), bool(vector[1]), bool(vector[2]))
+        elif operation == "SetAngularLock":
+            actor.set_angular_lock(bool(vector[0]), bool(vector[1]), bool(vector[2]))
         else:
             raise ValueError(f"Unsupported operation '{operation}'")
 

--- a/editor/plugins/ScratchTool/main.py
+++ b/editor/plugins/ScratchTool/main.py
@@ -1,41 +1,51 @@
 import ctypes
+import hashlib
+import importlib.util
 import json
+import logging
 import os
+from pathlib import Path
 import sys
 import threading
+import time
+from typing import Any, Optional
 
 from CoronaCore.core.corona_editor import CoronaEditor
-import logging
-
+from CoronaCore.utils.proejct_utils import (
+    cancel_pending_auto_saves,
+    flush_pending_auto_saves,
+    get_project_scenes,
+)
 from CoronaPlugin.core.corona_plugin_base import PluginBase
-from utils.settings import core_path
+from utils.settings import core_path, settings_manager
 
 logger = logging.getLogger(__name__)
 
 
-def _force_kill_thread(thread: threading.Thread, timeout: float = 3.0):
-    """强制终止线程：先 request_stop，等待 timeout 秒，未退出则注入 SystemExit"""
+def _force_kill_thread(
+    thread: threading.Thread,
+    timeout: float = 3.0,
+    context_id: str | None = None,
+):
+    """请求停止脚本线程；超时后注入 SystemExit 兜底。"""
     from CoronaCore.utils import corona_engine_scratch
 
-    corona_engine_scratch.request_stop()
-
+    corona_engine_scratch.request_stop(context_id)
     thread.join(timeout=timeout)
     if not thread.is_alive():
-        return True  # 正常退出
+        return True
 
-    # 仍未退出 → 用 ctypes 注入异常强制终止
-    logger.warning(f"[ScratchTool] 线程 {timeout}s 内未退出，强制注入 SystemExit")
+    logger.warning("[ScratchTool] thread did not stop in %.1fs; injecting SystemExit", timeout)
     tid = thread.ident
     if tid is not None:
         res = ctypes.pythonapi.PyThreadState_SetAsyncExc(
             ctypes.c_ulong(tid), ctypes.py_object(SystemExit)
         )
         if res == 0:
-            logger.error(f"[ScratchTool] 强制终止失败：无效线程 ID {tid}")
+            logger.error("[ScratchTool] invalid thread id: %s", tid)
         elif res > 1:
-            # 多线程状态被修改，需要恢复
             ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_ulong(tid), None)
-            logger.error(f"[ScratchTool] 强制终止异常：修改了多个线程状态，已回滚")
+            logger.error("[ScratchTool] SystemExit injection touched multiple threads; rolled back")
 
     thread.join(timeout=1.0)
     return not thread.is_alive()
@@ -43,250 +53,785 @@ def _force_kill_thread(thread: threading.Thread, timeout: float = 3.0):
 
 @PluginBase.register_web("ScratchTool")
 class ScratchTool(PluginBase):
-    # 脚本存放目录：Backend/script/（与 runScript.py 的 import 路径一致）
     script_dir = core_path.repo_root / "Backend" / "script"
     os.makedirs(script_dir, exist_ok=True)
 
-    # 当前执行的线程引用（用于停止控制）
-    _exec_thread = None
+    _exec_thread: Optional[threading.Thread] = None
+    _exec_context_id: Optional[str] = None
     _exec_lock = threading.Lock()
 
+    _preview_lock = threading.RLock()
+    _preview_threads: list[dict[str, Any]] = []
+    _preview_status = "idle"
+    _preview_errors: list[str] = []
+    _preview_warnings: list[str] = []
+    _preview_state_snapshot: Optional[dict[str, Any]] = None
+
+    # ------------------------------------------------------------------
+    # Project Blockly persistence
+    # ------------------------------------------------------------------
     @classmethod
-    def execute_python_code(cls, code: str, index: int,
-                            scene_name: str = "", actor_name: str = "") -> str:
+    def _active_project_path(cls) -> Path:
+        project_path = settings_manager.active_project_path
+        if not project_path and CoronaEditor.CoronaEngine is not None:
+            project_path = getattr(CoronaEditor.CoronaEngine, "active_project_path", None)
+        if not project_path:
+            raise RuntimeError("没有打开的项目，无法保存或运行积木")
+        return Path(project_path)
+
+    @classmethod
+    def _blockly_dir(cls) -> Path:
+        directory = cls._active_project_path() / "Scripts" / "blockly"
+        directory.mkdir(parents=True, exist_ok=True)
+        return directory
+
+    @classmethod
+    def _manifest_path(cls) -> Path:
+        return cls._blockly_dir() / "manifest.json"
+
+    @classmethod
+    def _load_manifest(cls) -> dict:
+        path = cls._manifest_path()
+        if not path.exists():
+            return {"targets": []}
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                return {"targets": []}
+            targets = data.get("targets")
+            if not isinstance(targets, list):
+                data["targets"] = []
+            return data
+        except Exception:
+            logger.exception("[ScratchTool] failed to load manifest: %s", path)
+            return {"targets": []}
+
+    @classmethod
+    def _write_manifest(cls, manifest: dict) -> None:
+        path = cls._manifest_path()
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, ensure_ascii=False, indent=2)
+
+    @staticmethod
+    def _target_id(target_type: str, scene_name: str = "", actor_name: str = "") -> str:
+        if target_type == "project":
+            return "project:global"
+        return f"actor:{scene_name}:{actor_name}"
+
+    @staticmethod
+    def _target_digest(target_id: str) -> str:
+        return hashlib.sha1(target_id.encode("utf-8")).hexdigest()[:12]
+
+    @staticmethod
+    def _normalize_payload(payload: Any) -> dict:
+        if payload is None:
+            return {}
+        if isinstance(payload, str):
+            return json.loads(payload) if payload.strip() else {}
+        if isinstance(payload, dict):
+            return payload
+        raise TypeError("payload must be an object")
+
+    @staticmethod
+    def _with_context_prelude(code: str, target_type: str, scene_name: str, actor_name: str) -> str:
+        prelude = "from CoronaCore.utils import corona_engine_scratch as _CE\n"
+        if target_type == "project":
+            prelude += "_CE.set_project_global()\n"
+        elif scene_name and actor_name:
+            prelude += f"_CE.set_target({scene_name!r}, {actor_name!r})\n"
+        return prelude + (code or "")
+
+    @classmethod
+    def save_blockly_target(cls, payload: dict | str) -> dict:
         """
-        保存 Blockly 生成的 Python 代码到 Backend/script/，
-        然后在独立线程中动态加载并执行 run() 函数
+        Save generated Python and Blockly workspace JSON into the active project.
 
-        此方法立即返回，不等待执行完成。执行状态通过 stop_script_execution() 控制。
-
-        Args:
-            code: Blockly 生成的 Python 代码
-            index: 脚本索引
-            scene_name: 目标场景名称（可选，用于绑定到场景中的真实 Actor）
-            actor_name: 目标 Actor 名称（可选）
+        Manifest schema:
+        { targets: [{ id, target_type, scene_name, actor_name, code_path,
+                      workspace_path, updated_at, enabled }] }
         """
-        import time
-        start_time = time.perf_counter()
+        try:
+            data = cls._normalize_payload(payload)
+            target_type = data.get("target_type") or "actor"
+            if target_type not in ("project", "actor"):
+                return {"status": "error", "message": f"unsupported target_type: {target_type}"}
 
+            scene_name = data.get("scene_name") or ""
+            actor_name = data.get("actor_name") or ""
+            if target_type == "actor" and (not scene_name or not actor_name):
+                return {"status": "error", "message": "actor target requires scene_name and actor_name"}
+            if target_type == "project":
+                scene_name = ""
+                actor_name = ""
+
+            target_id = cls._target_id(target_type, scene_name, actor_name)
+            digest = cls._target_digest(target_id)
+            prefix = "project_global" if target_type == "project" else "actor"
+            blockly_dir = cls._blockly_dir()
+            code_path = blockly_dir / f"{prefix}_{digest}.py"
+            workspace_path = blockly_dir / f"{prefix}_{digest}.blockly.json"
+            project_path = cls._active_project_path()
+
+            code = cls._with_context_prelude(
+                str(data.get("code") or ""),
+                target_type,
+                scene_name,
+                actor_name,
+            )
+            with open(code_path, "w", encoding="utf-8") as f:
+                f.write(code)
+            with open(workspace_path, "w", encoding="utf-8") as f:
+                json.dump(data.get("workspace") or {}, f, ensure_ascii=False, indent=2)
+
+            def _rel(path: Path) -> str:
+                return path.relative_to(project_path).as_posix()
+
+            target = {
+                "id": target_id,
+                "target_type": target_type,
+                "scene_name": scene_name,
+                "actor_name": actor_name,
+                "code_path": _rel(code_path),
+                "workspace_path": _rel(workspace_path),
+                "updated_at": time.time(),
+                "enabled": bool(data.get("enabled", True)),
+            }
+
+            manifest = cls._load_manifest()
+            targets = [t for t in manifest.get("targets", []) if t.get("id") != target_id]
+            targets.append(target)
+            targets.sort(key=lambda t: (0 if t.get("target_type") == "project" else 1,
+                                        t.get("scene_name", ""),
+                                        t.get("actor_name", "")))
+            manifest["targets"] = targets
+            cls._write_manifest(manifest)
+
+            return {"status": "saved", "target": target}
+        except Exception as exc:
+            logger.exception("[ScratchTool] save_blockly_target failed")
+            return {"status": "error", "message": str(exc)}
+
+    @classmethod
+    def load_blockly_target(cls, payload: dict | str) -> dict:
+        """Load a saved Blockly workspace for one project/actor target."""
+        try:
+            data = cls._normalize_payload(payload)
+            target_type = data.get("target_type") or "actor"
+            if target_type not in ("project", "actor"):
+                return {"status": "error", "message": f"unsupported target_type: {target_type}"}
+
+            scene_name = data.get("scene_name") or ""
+            actor_name = data.get("actor_name") or ""
+            if target_type == "project":
+                scene_name = ""
+                actor_name = ""
+            elif not scene_name or not actor_name:
+                return {"status": "error", "message": "actor target requires scene_name and actor_name"}
+
+            target_id = cls._target_id(target_type, scene_name, actor_name)
+            manifest = cls._load_manifest()
+            target = next(
+                (item for item in manifest.get("targets", []) if item.get("id") == target_id),
+                None,
+            )
+            if not target:
+                return {
+                    "status": "missing",
+                    "target": {
+                        "id": target_id,
+                        "target_type": target_type,
+                        "scene_name": scene_name,
+                        "actor_name": actor_name,
+                    },
+                    "workspace": {},
+                }
+
+            workspace_rel = target.get("workspace_path") or ""
+            workspace_path = (cls._active_project_path() / workspace_rel).resolve()
+            project_path = cls._active_project_path().resolve()
+            try:
+                workspace_path.relative_to(project_path)
+            except ValueError:
+                return {"status": "error", "message": "workspace_path escapes active project"}
+
+            if not workspace_path.exists():
+                return {"status": "missing", "target": target, "workspace": {}}
+            with open(workspace_path, "r", encoding="utf-8") as f:
+                workspace = json.load(f)
+            if not isinstance(workspace, dict):
+                workspace = {}
+            return {"status": "loaded", "target": target, "workspace": workspace}
+        except Exception as exc:
+            logger.exception("[ScratchTool] load_blockly_target failed")
+            return {"status": "error", "message": str(exc)}
+
+    # ------------------------------------------------------------------
+    # Legacy single-code execution
+    # ------------------------------------------------------------------
+    @classmethod
+    def execute_python_code(
+        cls,
+        code: str,
+        index: int,
+        scene_name: str = "",
+        actor_name: str = "",
+        target_type: str = "actor",
+    ) -> dict:
         try:
             filename = f"blockly_code{'_' + str(index) if index else ''}.py"
-            filepath = os.path.join(cls.script_dir, filename)
+            filepath = cls.script_dir / filename
 
-            # 1. 如果有 scene/actor 上下文，在代码前注入 set_target 调用
-            final_code = code
-            if scene_name and actor_name:
-                set_target_prelude = (
-                    f"from CoronaCore.utils import corona_engine_scratch as _CE\n"
-                    f"_CE.set_target({repr(scene_name)}, {repr(actor_name)})\n"
-                )
-                final_code = set_target_prelude + code
-
-            # 2. 写入代码文件（先清除旧的 blockly_code*.py，避免旧脚本中的错误影响）
             for old_file in os.listdir(cls.script_dir):
                 if old_file.startswith("blockly_code") and old_file.endswith(".py"):
-                    old_path = os.path.join(cls.script_dir, old_file)
                     try:
-                        os.remove(old_path)
+                        os.remove(cls.script_dir / old_file)
                     except Exception:
                         pass
 
+            final_code = cls._with_context_prelude(code, target_type, scene_name, actor_name)
             with open(filepath, "w", encoding="utf-8") as f:
                 f.write(final_code)
 
-            # 3. 生成 runScript.py（聚合所有 blockly_code*.py）
-            script_files = sorted(
-                f.replace(".py", "")
-                for f in os.listdir(cls.script_dir)
-                if f.startswith("blockly_code") and f.endswith(".py")
-            )
-
             run_script_path = core_path.repo_root / "Backend" / "runScript.py"
-            run_script_content = ""
-            for script in script_files:
-                run_script_content += f"from Backend.script import {script}\n"
-            run_script_content += "\n\ndef run():\n"
-            for script in script_files:
-                run_script_content += f"    {script}.run()\n"
-
             with open(run_script_path, "w", encoding="utf-8") as f:
-                f.write(run_script_content)
-
-            # 4. 修正生成代码中的旧路径引用
-            try:
-                for sf in script_files:
-                    sf_path = os.path.join(cls.script_dir, f"{sf}.py")
-                    if os.path.exists(sf_path):
-                        with open(sf_path, 'r', encoding='utf-8') as sf_f:
-                            content = sf_f.read()
-                        new_content = content.replace('from utils.', 'from Backend.utils.').replace(
-                            'from corona_engine_fallback import',
-                            'from Backend.engine_core.corona_engine_fallback import')
-                        if new_content != content:
-                            with open(sf_path, 'w', encoding='utf-8') as sf_f:
-                                sf_f.write(new_content)
-            except Exception:
-                pass
-
-            elapsed_save = (time.perf_counter() - start_time) * 1000
-            target_info = f", target={scene_name}/{actor_name}" if scene_name and actor_name else ""
-            logger.info(f"[ScratchTool] 脚本保存完成: {elapsed_save:.1f}ms -> {filepath}{target_info}")
-
-            # 5. 清除 Backend 命名空间包的所有缓存模块 + .pyc 字节码
-            import importlib
-            modules_to_clear = [
-                name for name in sys.modules.keys()
-                if name == 'Backend' or name.startswith('Backend.')
-            ]
-            for mod_name in modules_to_clear:
-                try:
-                    del sys.modules[mod_name]
-                except KeyError:
-                    pass
-
-            # 同时删除 __pycache__ 中的 .pyc 防止字节码缓存
-            import glob as _glob
-            pycache_dirs = [
-                os.path.join(cls.script_dir, '__pycache__'),
-                core_path.repo_root / 'Backend' / '__pycache__',
-            ]
-            for pc_dir in pycache_dirs:
-                if os.path.isdir(pc_dir):
-                    for pyc_file in _glob.glob(os.path.join(pc_dir, 'blockly_code*')):
-                        try:
-                            os.remove(pyc_file)
-                        except Exception:
-                            pass
-                    for pyc_file in _glob.glob(os.path.join(pc_dir, 'runScript*')):
-                        try:
-                            os.remove(pyc_file)
-                        except Exception:
-                            pass
+                f.write("from Backend.script import blockly_code\n\n\ndef run():\n    blockly_code.run()\n")
 
             backend_root = str(core_path.repo_root)
             if backend_root not in sys.path:
                 sys.path.insert(0, backend_root)
+            cls._clear_backend_cache()
 
-            # 重置 corona_engine_scratch 的全部运行时状态
-            try:
-                from CoronaCore.utils import corona_engine_scratch
-                corona_engine_scratch.reset_state()
-                # 开启 fallback 静默模式（抑制 Geometry.set_position 等打印）
-                from CoronaCore.utils import corona_engine_fallback
-                corona_engine_fallback.set_quiet(True)
-                logger.debug("[ScratchTool] 运行时状态已重置")
-            except Exception as reset_err:
-                logger.warning(f"[ScratchTool] 状态重置失败（使用旧API降级）: {reset_err}")
-                try:
-                    corona_engine_scratch.reset_stop()
-                except Exception:
-                    pass
-
-            # 6. 在后台线程中执行脚本（主线程立即返回，不阻塞 UI）
-            def _run_in_thread():
-                exec_start = time.perf_counter()
-                try:
-                    from Backend import runScript
-                    importlib.reload(runScript)
-                    runScript.run()
-                    elapsed_exec = (time.perf_counter() - exec_start) * 1000
-                    logger.info(f"[ScratchTool] 脚本执行完成: {elapsed_exec:.1f}ms")
-                except SystemExit:
-                    # 正常的停止流程（check_stop 触发），不是错误
-                    elapsed_exec = (time.perf_counter() - exec_start) * 1000
-                    logger.info(f"[ScratchTool] 脚本被停止: {elapsed_exec:.1f}ms")
-                except Exception as exec_err:
-                    elapsed_exec = (time.perf_counter() - exec_start) * 1000
-                    logger.exception(
-                        f"[ScratchTool] 脚本执行失败 ({elapsed_exec:.1f}ms): {exec_err}")
-                finally:
-                    # 清理线程引用
-                    with cls._exec_lock:
-                        if cls._exec_thread is threading.current_thread():
-                            cls._exec_thread = None
-
-            # 取消上一个未完成的线程
             old_thread = None
+            old_context = None
             with cls._exec_lock:
                 if cls._exec_thread and cls._exec_thread.is_alive():
                     old_thread = cls._exec_thread
-
+                    old_context = cls._exec_context_id
             if old_thread is not None:
-                _force_kill_thread(old_thread, timeout=0.5)
+                _force_kill_thread(old_thread, timeout=0.5, context_id=old_context)
+
+            context_id = cls._target_id(target_type, scene_name, actor_name)
+
+            def _run_in_thread():
+                cls._run_code_file(
+                    filepath,
+                    {
+                        "id": context_id,
+                        "target_type": target_type,
+                        "scene_name": scene_name,
+                        "actor_name": actor_name,
+                    },
+                    single_exec=True,
+                )
+                with cls._exec_lock:
+                    if cls._exec_thread is threading.current_thread():
+                        cls._exec_thread = None
+                        cls._exec_context_id = None
 
             with cls._exec_lock:
+                cls._exec_context_id = context_id
                 cls._exec_thread = threading.Thread(
                     target=_run_in_thread, daemon=True, name="blockly-exec"
                 )
                 cls._exec_thread.start()
 
-            return json.dumps({"status": "started", "filepath": filepath})
-
-        except Exception as e:
-            logger.exception("[ScratchTool] 处理Python代码时出错: %s", str(e))
-            return json.dumps({"status": "error", "message": str(e)})
+            return {"status": "started", "filepath": str(filepath)}
+        except Exception as exc:
+            logger.exception("[ScratchTool] execute_python_code failed")
+            return {"status": "error", "message": str(exc)}
 
     @classmethod
-    def stop_script_execution(cls) -> str:
-        """
-        停止当前正在执行的脚本
-
-        1. 设置停止标志 → 循环内的 check_stop() 抛出 SystemExit
-        2. 等待 0.5s → 如未退出，用 ctypes 注入 SystemExit
-        """
+    def stop_script_execution(cls) -> dict:
         thread_to_stop = None
+        context_id = None
         with cls._exec_lock:
             if cls._exec_thread and cls._exec_thread.is_alive():
                 thread_to_stop = cls._exec_thread
+                context_id = cls._exec_context_id
 
         if thread_to_stop is not None:
-            killed = _force_kill_thread(thread_to_stop, timeout=0.5)
-            if killed:
-                logger.info("[ScratchTool] 脚本已停止")
-            else:
-                logger.error("[ScratchTool] 脚本停止失败（线程未响应）")
+            _force_kill_thread(thread_to_stop, timeout=0.5, context_id=context_id)
 
-            with cls._exec_lock:
-                if cls._exec_thread is thread_to_stop:
-                    cls._exec_thread = None
-
-        return json.dumps({"status": "stopped"})
+        with cls._exec_lock:
+            cls._exec_thread = None
+            cls._exec_context_id = None
+        return {"status": "stopped"}
 
     @classmethod
-    def get_script_status(cls) -> str:
-        """查询当前脚本执行状态：running / idle"""
+    def get_script_status(cls) -> dict:
         with cls._exec_lock:
             if cls._exec_thread and cls._exec_thread.is_alive():
-                return json.dumps({"status": "running"})
-            return json.dumps({"status": "idle"})
+                return {"status": "running"}
+        return {"status": "idle"}
+
+    # ------------------------------------------------------------------
+    # Project preview
+    # ------------------------------------------------------------------
+    @classmethod
+    def start_game_preview(cls, payload: dict | str | None = None) -> dict:
+        data = cls._normalize_payload(payload)
+        scope = data.get("scope", "project")
+        if scope != "project":
+            return {"status": "error", "message": f"unsupported preview scope: {scope}"}
+
+        cls.stop_game_preview()
+
+        try:
+            flush_pending_auto_saves()
+            targets, warnings = cls._prepare_preview_targets()
+            flush_pending_auto_saves()
+        except Exception as exc:
+            logger.exception("[ScratchTool] start_game_preview prepare failed")
+            return {"status": "error", "message": str(exc)}
+
+        if not targets:
+            with cls._preview_lock:
+                cls._preview_errors = []
+                cls._preview_warnings = list(warnings)
+                cls._preview_threads = []
+                cls._preview_status = "idle"
+            return {
+                "status": "idle",
+                "started_count": 0,
+                "errors": [],
+                "warnings": warnings,
+            }
+
+        try:
+            state_snapshot = cls._create_preview_state_snapshot()
+        except Exception as exc:
+            logger.exception("[ScratchTool] preview state snapshot failed")
+            return {"status": "error", "message": f"创建预览状态快照失败: {exc}"}
+
+        with cls._preview_lock:
+            cls._preview_errors = []
+            cls._preview_warnings = list(warnings)
+            cls._preview_threads = []
+            cls._preview_status = "running" if targets else "idle"
+            cls._preview_state_snapshot = state_snapshot
+
+        for target in targets:
+            code_path = cls._active_project_path() / target["code_path"]
+            thread = threading.Thread(
+                target=cls._run_preview_target,
+                args=(code_path, target),
+                daemon=True,
+                name=f"blockly-preview-{cls._target_digest(target['id'])}",
+            )
+            with cls._preview_lock:
+                cls._preview_threads.append({"thread": thread, "target": target})
+            thread.start()
+
+        return {
+            "status": "running" if targets else "idle",
+            "started_count": len(targets),
+            "errors": [],
+            "warnings": warnings,
+        }
 
     @classmethod
-    def key_event(cls, key: str, modifiers: str = "", display_key: str = "") -> str:
-        """CEF 桥接：分发键盘按下事件
-        Args:
-            key: 物理键码 (e.code, 如 'KeyA', 'Digit0', 'BracketRight')
-            modifiers: 修饰键 (如 'Ctrl,Shift')
-            display_key: 显示字符 (e.key, 如 'a', '0', ']')
-        """
+    def stop_game_preview(cls) -> dict:
+        with cls._preview_lock:
+            infos = list(cls._preview_threads)
+            if infos:
+                cls._preview_status = "stopping"
+
+        from CoronaCore.utils import corona_engine_scratch
+
+        corona_engine_scratch.request_stop_all()
+        stopped = 0
+        for info in infos:
+            thread = info.get("thread")
+            target = info.get("target") or {}
+            if thread and thread.is_alive():
+                if _force_kill_thread(thread, timeout=0.5, context_id=target.get("id")):
+                    stopped += 1
+            else:
+                stopped += 1
+
+        with cls._preview_lock:
+            cls._preview_threads = [
+                info for info in cls._preview_threads
+                if info.get("thread") and info["thread"].is_alive()
+            ]
+            cls._preview_status = "idle" if not cls._preview_threads else "stopping"
+            live_count = len(cls._preview_threads)
+
+        if live_count:
+            return {
+                "status": cls._preview_status,
+                "stopped_count": stopped,
+                "restored": False,
+                "restore_error": "preview threads are still running",
+            }
+
+        restored, restore_error = cls._restore_preview_state_snapshot()
+        with cls._preview_lock:
+            if restore_error:
+                cls._preview_status = "error"
+            else:
+                cls._preview_status = "idle"
+
+        return {
+            "status": cls._preview_status,
+            "stopped_count": stopped,
+            "restored": restored,
+            **({"restore_error": restore_error} if restore_error else {}),
+        }
+
+    @classmethod
+    def get_game_preview_status(cls) -> dict:
+        with cls._preview_lock:
+            cls._prune_preview_locked()
+            live = [info for info in cls._preview_threads if info["thread"].is_alive()]
+            return {
+                "status": cls._preview_status,
+                "running_count": len(live),
+                "has_snapshot": cls._preview_state_snapshot is not None,
+                "errors": list(cls._preview_errors),
+                "warnings": list(cls._preview_warnings),
+            }
+
+    @classmethod
+    def _prepare_preview_targets(cls) -> tuple[list[dict], list[str]]:
+        manifest = cls._load_manifest()
+        project_scenes = cls._project_scene_routes()
+        scene_order = {route: i for i, route in enumerate(project_scenes)}
+        targets: list[dict] = []
+        warnings: list[str] = []
+
+        from CoronaCore.core.managers import scene_manager
+
+        for route in project_scenes:
+            try:
+                scene_manager.get_or_create(route)
+            except Exception as exc:
+                warnings.append(f"场景加载失败，已跳过: {route} ({exc})")
+
+        for target in manifest.get("targets", []):
+            if not target.get("enabled", True):
+                continue
+            target_type = target.get("target_type")
+            code_path = target.get("code_path")
+            if not code_path or not (cls._active_project_path() / code_path).exists():
+                warnings.append(f"积木代码不存在，已跳过: {target.get('id')}")
+                continue
+            if target_type == "project":
+                targets.append(target)
+                continue
+            if target_type != "actor":
+                warnings.append(f"未知积木目标，已跳过: {target.get('id')}")
+                continue
+
+            scene_name = target.get("scene_name", "")
+            actor_name = target.get("actor_name", "")
+            if scene_name not in scene_order:
+                warnings.append(f"目标场景不在项目列表中，已跳过: {scene_name}/{actor_name}")
+                continue
+            scene = scene_manager.get_or_create(scene_name)
+            if not scene or not scene.find_actor(actor_name):
+                warnings.append(f"目标物体不存在，已跳过: {scene_name}/{actor_name}")
+                continue
+            targets.append(target)
+
+        targets.sort(
+            key=lambda t: (
+                0 if t.get("target_type") == "project" else 1,
+                scene_order.get(t.get("scene_name", ""), 999999),
+                t.get("actor_name", ""),
+            )
+        )
+        return targets, warnings
+
+    @classmethod
+    def _create_preview_state_snapshot(cls) -> dict[str, Any]:
+        from CoronaCore.core.managers import scene_manager
+
+        snapshot: dict[str, Any] = {"scenes": {}}
+        for route in cls._project_scene_routes():
+            scene = scene_manager.get_or_create(route)
+            scene_state: dict[str, Any] = {
+                "actors": {},
+                "cameras": {},
+                "environment": {},
+                "enabled": cls._safe_call(scene, "is_enabled"),
+                "simulation_enabled": cls._safe_call(scene, "is_simulation_enabled"),
+            }
+
+            env = scene.get_environment() if hasattr(scene, "get_environment") else None
+            if env is not None:
+                scene_state["environment"] = {
+                    "sun_direction": cls._safe_call(env, "get_sun_direction"),
+                    "floor_grid": cls._safe_call(env, "get_floor_grid"),
+                    "gravity": cls._safe_call(env, "get_gravity"),
+                    "floor_y": cls._safe_call(env, "get_floor_y"),
+                    "floor_restitution": cls._safe_call(env, "get_floor_restitution"),
+                    "fixed_dt": cls._safe_call(env, "get_fixed_dt"),
+                }
+
+            for camera in scene.get_cameras():
+                camera_name = getattr(camera, "name", "")
+                if not camera_name:
+                    continue
+                scene_state["cameras"][camera_name] = {
+                    "position": cls._safe_call(camera, "get_position"),
+                    "forward": cls._safe_call(camera, "get_forward"),
+                    "world_up": cls._safe_call(camera, "get_world_up"),
+                    "fov": cls._safe_call(camera, "get_fov"),
+                    "output_mode": cls._safe_call(camera, "get_output_mode"),
+                    "width": getattr(camera, "width", None),
+                    "height": getattr(camera, "height", None),
+                }
+
+            for actor in scene.get_actors():
+                actor_name = getattr(actor, "name", "")
+                if not actor_name:
+                    continue
+                scene_state["actors"][actor_name] = {
+                    "position": cls._safe_call(actor, "get_position"),
+                    "rotation": cls._safe_call(actor, "get_rotation"),
+                    "scale": cls._safe_call(actor, "get_scale"),
+                    "visible": cls._safe_call(actor, "get_visible"),
+                    "mass": cls._safe_call(actor, "get_mass"),
+                    "restitution": cls._safe_call(actor, "get_restitution"),
+                    "damping": cls._safe_call(actor, "get_damping"),
+                    "physics_enabled": cls._safe_call(actor, "get_physics_enabled"),
+                    "collision_enabled": cls._safe_call(actor, "get_collision_enabled"),
+                }
+
+            snapshot["scenes"][route] = scene_state
+
+        logger.info("[ScratchTool] preview state snapshot captured: %d scenes", len(snapshot["scenes"]))
+        return snapshot
+
+    @classmethod
+    def _restore_preview_state_snapshot(cls) -> tuple[bool, str | None]:
+        with cls._preview_lock:
+            snapshot = cls._preview_state_snapshot
+
+        if not snapshot:
+            return False, None
+
+        try:
+            cancel_pending_auto_saves()
+            from CoronaCore.core.managers import scene_manager
+
+            restored_scenes = set()
+            for route, scene_state in (snapshot.get("scenes") or {}).items():
+                scene = scene_manager.get(route)
+                if scene is None:
+                    continue
+
+                cls._restore_scene_state(scene, scene_state)
+                restored_scenes.add(route)
+                try:
+                    scene.save_data()
+                except Exception:
+                    logger.exception("[ScratchTool] failed to save restored scene: %s", route)
+
+            with cls._preview_lock:
+                cls._preview_state_snapshot = None
+
+            cls._notify_preview_state_restored(restored_scenes)
+            logger.info("[ScratchTool] preview state restored: %d scenes", len(restored_scenes))
+            return True, None
+        except Exception as exc:
+            logger.exception("[ScratchTool] preview state restore failed")
+            return False, str(exc)
+
+    @staticmethod
+    def _safe_call(target: object, method_name: str):
+        if target is None or not hasattr(target, method_name):
+            return None
+        try:
+            return getattr(target, method_name)()
+        except Exception:
+            return None
+
+    @staticmethod
+    def _apply_if_present(target: object, method_name: str, value, *extra_args) -> None:
+        if value is None or target is None or not hasattr(target, method_name):
+            return
+        try:
+            getattr(target, method_name)(value, *extra_args)
+        except TypeError:
+            getattr(target, method_name)(value)
+        except Exception:
+            logger.exception("[ScratchTool] restore %s failed", method_name)
+
+    @classmethod
+    def _restore_scene_state(cls, scene: object, scene_state: dict[str, Any]) -> None:
+        cls._apply_if_present(scene, "set_enabled", scene_state.get("enabled"))
+        cls._apply_if_present(scene, "set_simulation_enabled", scene_state.get("simulation_enabled"))
+
+        env = scene.get_environment() if hasattr(scene, "get_environment") else None
+        env_state = scene_state.get("environment") or {}
+        if env is not None:
+            cls._apply_if_present(env, "set_sun_direction", env_state.get("sun_direction"))
+            cls._apply_if_present(env, "set_floor_grid", env_state.get("floor_grid"))
+            cls._apply_if_present(env, "set_gravity", env_state.get("gravity"))
+            cls._apply_if_present(env, "set_floor_y", env_state.get("floor_y"))
+            cls._apply_if_present(env, "set_floor_restitution", env_state.get("floor_restitution"))
+            cls._apply_if_present(env, "set_fixed_dt", env_state.get("fixed_dt"))
+
+        for camera_name, camera_state in (scene_state.get("cameras") or {}).items():
+            camera = scene.find_camera(camera_name) if hasattr(scene, "find_camera") else None
+            if camera is None:
+                continue
+            position = camera_state.get("position")
+            forward = camera_state.get("forward")
+            world_up = camera_state.get("world_up")
+            fov = camera_state.get("fov")
+            if position is not None and forward is not None and world_up is not None and fov is not None:
+                cls._apply_if_present(camera, "set", position, forward, world_up, fov)
+            output_mode = camera_state.get("output_mode")
+            cls._apply_if_present(camera, "set_output_mode", output_mode)
+            width = camera_state.get("width")
+            height = camera_state.get("height")
+            if width is not None and height is not None:
+                cls._apply_if_present(camera, "set_size", int(width), int(height))
+
+        for actor_name, actor_state in (scene_state.get("actors") or {}).items():
+            actor = scene.find_actor(actor_name) if hasattr(scene, "find_actor") else None
+            if actor is None:
+                continue
+            cls._apply_if_present(actor, "set_position", actor_state.get("position"), True)
+            cls._apply_if_present(actor, "set_rotation", actor_state.get("rotation"), True)
+            cls._apply_if_present(actor, "set_scale", actor_state.get("scale"), True)
+            cls._apply_if_present(actor, "set_visible", actor_state.get("visible"))
+            cls._apply_if_present(actor, "set_mass", actor_state.get("mass"))
+            cls._apply_if_present(actor, "set_restitution", actor_state.get("restitution"))
+            cls._apply_if_present(actor, "set_damping", actor_state.get("damping"))
+            cls._apply_if_present(actor, "set_physics_enabled", actor_state.get("physics_enabled"))
+            cls._apply_if_present(actor, "set_collision_enabled", actor_state.get("collision_enabled"))
+
+    @staticmethod
+    def _notify_preview_state_restored(scene_routes: set[str]) -> None:
+        try:
+            selected_scene = CoronaEditor._selected_scene
+            selected_actor = CoronaEditor._selected_actor
+            for route in scene_routes or {selected_scene or ""}:
+                CoronaEditor.js_call_func("scene-tree-changed", [route])
+            if selected_scene and selected_actor:
+                CoronaEditor.js_call_func("actor-change", ["actor", selected_scene, selected_actor])
+            elif selected_scene:
+                CoronaEditor.js_call_func("actor-change", ["scene", selected_scene, ""])
+        except Exception:
+            logger.exception("[ScratchTool] failed to notify frontend after preview state restore")
+
+    @classmethod
+    def _project_scene_routes(cls) -> list[str]:
+        project_path = cls._active_project_path()
+        ini_path = project_path / "project.ini"
+        scenes = get_project_scenes(str(ini_path)) if ini_path.exists() else []
+        if not scenes and (project_path / "Scene").is_dir():
+            scenes = [
+                f"Scene/{path.name}"
+                for path in sorted((project_path / "Scene").iterdir())
+                if path.suffix == ".scene"
+            ]
+        entrance = ""
+        try:
+            if settings_manager.active_project_config:
+                entrance = settings_manager.active_project_config["Project"].get("entrance_scene", "")
+        except Exception:
+            entrance = ""
+        if entrance and entrance not in scenes:
+            scenes.insert(0, entrance)
+        return scenes
+
+    @classmethod
+    def _run_preview_target(cls, code_path: Path, target: dict) -> None:
+        cls._run_code_file(code_path, target, single_exec=False)
+        with cls._preview_lock:
+            cls._prune_preview_locked()
+
+    @classmethod
+    def _run_code_file(cls, code_path: Path, target: dict, single_exec: bool) -> None:
+        from CoronaCore.utils import corona_engine_fallback, corona_engine_scratch
+
+        context_id = target.get("id") or cls._target_id(
+            target.get("target_type", "actor"),
+            target.get("scene_name", ""),
+            target.get("actor_name", ""),
+        )
+        ctx = corona_engine_scratch.create_context(
+            context_id=context_id,
+            target_type=target.get("target_type", "actor"),
+            scene_name=target.get("scene_name", ""),
+            actor_name=target.get("actor_name", ""),
+        )
+        corona_engine_scratch.bind_context(ctx)
+        corona_engine_fallback.set_quiet(True)
+
+        module_name = f"blockly_runtime_{cls._target_digest(context_id)}_{int(time.time() * 1000)}"
+        try:
+            spec = importlib.util.spec_from_file_location(module_name, code_path)
+            if spec is None or spec.loader is None:
+                raise RuntimeError(f"无法加载积木脚本: {code_path}")
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = module
+            spec.loader.exec_module(module)
+            if hasattr(module, "run"):
+                module.run()
+            if (ctx.key_handler is not None or ctx.mouse_handler is not None) and not ctx.stop_requested:
+                while not ctx.stop_requested:
+                    time.sleep(0.1)
+        except SystemExit:
+            logger.info("[ScratchTool] script stopped: %s", context_id)
+        except Exception as exc:
+            logger.exception("[ScratchTool] script failed: %s", context_id)
+            if not single_exec:
+                with cls._preview_lock:
+                    cls._preview_errors.append(f"{context_id}: {exc}")
+                    cls._preview_status = "error"
+        finally:
+            sys.modules.pop(module_name, None)
+            corona_engine_scratch.release_context(ctx)
+
+    @classmethod
+    def _prune_preview_locked(cls) -> None:
+        cls._preview_threads = [
+            info for info in cls._preview_threads
+            if info.get("thread") and info["thread"].is_alive()
+        ]
+        if not cls._preview_threads and cls._preview_status in ("running", "stopping"):
+            cls._preview_status = "error" if cls._preview_errors else "idle"
+
+    @staticmethod
+    def _clear_backend_cache() -> None:
+        for name in list(sys.modules.keys()):
+            if name == "Backend" or name.startswith("Backend."):
+                sys.modules.pop(name, None)
+
+    # ------------------------------------------------------------------
+    # Input bridge
+    # ------------------------------------------------------------------
+    @classmethod
+    def key_event(cls, key: str, modifiers: str = "", display_key: str = "") -> dict:
         from CoronaCore.utils import corona_engine_scratch
 
         mods = [m.strip() for m in modifiers.split(",") if m.strip()] if modifiers else []
         corona_engine_scratch.handle_key_event(key, mods, display_key or key)
-        return json.dumps({"status": "ok"})
+        return {"status": "ok"}
 
     @classmethod
-    def key_release(cls, key: str, display_key: str = "") -> str:
-        """CEF 桥接：分发键盘释放事件"""
+    def key_release(cls, key: str, display_key: str = "") -> dict:
         from CoronaCore.utils import corona_engine_scratch
 
         corona_engine_scratch.handle_key_release(key, display_key or key)
-        return json.dumps({"status": "ok"})
+        return {"status": "ok"}
 
     @classmethod
-    def mouse_event(cls, event_type: str, button: str = "",
-                    x: float = 0.0, y: float = 0.0) -> str:
-        """CEF 桥接：分发鼠标事件到积木脚本的 handle_mouse()"""
+    def mouse_event(
+        cls,
+        event_type: str,
+        button: str = "",
+        x: float = 0.0,
+        y: float = 0.0,
+    ) -> dict:
         from CoronaCore.utils import corona_engine_scratch
 
         corona_engine_scratch.handle_mouse_event(event_type, button, x, y)
-        return json.dumps({"status": "ok"})
+        return {"status": "ok"}

--- a/examples/cef_subprocess/main.cpp
+++ b/examples/cef_subprocess/main.cpp
@@ -96,10 +96,10 @@ class SubprocessRenderHandler : public CefRenderProcessHandler {
                 return true;
             }
 
-            // ── setProperty: 属性编辑快速通道 (Mass/Restitution/Damping/Visible/Collision/Physics) ──
+            // ── setProperty: 属性编辑快速通道 ──
             if (name == "setProperty") {
                 // arguments: (actorHandle: number, propertyType: int, value: number)
-                // propertyType: 0=Mass, 1=Restitution, 2=Damping, 3=Visible, 4=CollisionEnabled, 5=PhysicsEnabled
+                // propertyType: 0=Mass, 1=Restitution, 2=Damping, 3=Visible, 4=CollisionEnabled, 5=PhysicsEnabled, 6=LinearLockMask, 7=AngularLockMask
                 if (arguments.size() < 3) {
                     exception = "setProperty(handle, propertyType, value) requires 3 arguments";
                     retval = CefV8Value::CreateBool(false);

--- a/include/corona/shared_data_hub.h
+++ b/include/corona/shared_data_hub.h
@@ -84,6 +84,10 @@ struct MechanicsDevice {
     // 力学碰撞检测开关：false 时完全禁用该物体的碰撞检测（物体不与其他物体或地面碰撞）
     bool bEnableCollision{true};
 
+    // 轴锁定位掩码：bit0=锁定X轴, bit1=锁定Y轴, bit2=锁定Z轴
+    uint8_t linear_lock_mask{0};   // 锁定线性运动（平移）的轴
+    uint8_t angular_lock_mask{0};  // 锁定角度运动（旋转）的轴
+
     // 碰撞回调函数
     std::function<void(std::uintptr_t, bool, const std::array<float, 3>&, const std::array<float, 3>&)> collision_callback;
 

--- a/include/corona/systems/script/corona_engine_api.h
+++ b/include/corona/systems/script/corona_engine_api.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -80,6 +81,14 @@ class Mechanics {
     // 碰撞检测开关：false 时物体不参与碰撞检测（不与其他物体或地面碰撞）
     void set_collision_enabled(bool enabled);
     [[nodiscard]] bool get_collision_enabled() const;
+
+    // 轴锁定：锁定指定轴上的线性运动（平移）
+    void set_linear_lock(bool lock_x, bool lock_y, bool lock_z);
+    [[nodiscard]] std::tuple<bool, bool, bool> get_linear_lock() const;
+
+    // 轴锁定：锁定指定轴上的角度运动（旋转）
+    void set_angular_lock(bool lock_x, bool lock_y, bool lock_z);
+    [[nodiscard]] std::tuple<bool, bool, bool> get_angular_lock() const;
 
     // 设置碰撞回调（参数为对方 actor 句柄、began(true=enter,false=exit)、法线、碰撞点）
     void set_collision_callback(std::function<void(std::uintptr_t, bool, const std::array<float, 3>&, const std::array<float, 3>&)> callback);

--- a/src/systems/mechanics/mechanics_system.cpp
+++ b/src/systems/mechanics/mechanics_system.cpp
@@ -387,6 +387,11 @@ static std::unordered_map<std::uintptr_t, ktm::fvec3> g_handle_to_last_move_call
 // 移动回调最小位移阈值（单位：米/坐标单位）
 constexpr float kMoveCallbackMinDistance = 0.1f;
 
+// 轴锁定位掩码常量
+constexpr uint8_t kLockAxisX = 0b001;
+constexpr uint8_t kLockAxisY = 0b010;
+constexpr uint8_t kLockAxisZ = 0b100;
+
 // ========== 延迟回调队列（同步执行，避免跨线程竞争） ==========
 static std::vector<std::function<void()>> g_deferred_move_callbacks;
 
@@ -411,6 +416,10 @@ static std::unordered_map<std::uintptr_t, ktm::fvec3> g_handle_to_angular_vel;  
 static std::unordered_map<std::uintptr_t, ktm::fquat> g_handle_orientation_quat;  // 与欧拉同步的朝向
 static std::unordered_map<std::uintptr_t, bool> g_handle_to_sleeping;             // true 则本帧不积分
 static std::unordered_map<std::uintptr_t, float> g_handle_to_sleep_timer;         // 低速累计时长
+
+// 轴锁定缓存（每帧从 MechanicsDevice 刷新）
+static std::unordered_map<std::uintptr_t, uint8_t> g_handle_to_linear_lock;   // 线性轴锁定位掩码
+static std::unordered_map<std::uintptr_t, uint8_t> g_handle_to_angular_lock;  // 角度轴锁定位掩码
 
 // ============================================================================
 // 碰撞网格（基于最低级 LOD 的三角形碰撞检测）
@@ -838,6 +847,8 @@ void MechanicsSystem::shutdown() {
     g_handle_orientation_quat.clear();
     g_handle_to_sleeping.clear();
     g_handle_to_sleep_timer.clear();
+    g_handle_to_linear_lock.clear();
+    g_handle_to_angular_lock.clear();
     g_handle_to_last_move_callback_time.clear();
     g_handle_to_last_move_callback_pos.clear();
     g_global_simulation_time = 0.0f;
@@ -940,11 +951,15 @@ void MechanicsSystem::update_physics() {
                                 handle_to_damping[h] = m_acc->damping;
                                 handle_to_restitution[h] = m_acc->restitution;
                                 handle_to_collision_enabled[h] = m_acc->bEnableCollision;  // 缓存碰撞开关
+                                g_handle_to_linear_lock[h] = m_acc->linear_lock_mask;    // 缓存线性轴锁
+                                g_handle_to_angular_lock[h] = m_acc->angular_lock_mask;  // 缓存角度轴锁
                             } else {
                                 handle_to_mass[h] = 1.0f;
                                 handle_to_damping[h] = 0.99f;
                                 handle_to_restitution[h] = 0.8f;
                                 handle_to_collision_enabled[h] = true;  // 读失败时默认开启碰撞
+                                g_handle_to_linear_lock[h] = 0;         // 读失败时默认不锁任何轴
+                                g_handle_to_angular_lock[h] = 0;
                             }
 
                             mechanics_handles.push_back(h);
@@ -1007,6 +1022,20 @@ void MechanicsSystem::update_physics() {
         av.z *= effective_rot_damping;
     }
 
+    // --- 阶段 2b：轴锁定强制执行 — 将已锁轴的速度/角速度分量清零 ---
+    for (std::uintptr_t h : mechanics_handles) {
+        if (g_handle_to_sleeping[h]) continue;
+        uint8_t lin_lock = g_handle_to_linear_lock[h];
+        if (lin_lock & kLockAxisX) g_handle_to_velocity[h].x = 0.0f;
+        if (lin_lock & kLockAxisY) g_handle_to_velocity[h].y = 0.0f;
+        if (lin_lock & kLockAxisZ) g_handle_to_velocity[h].z = 0.0f;
+
+        uint8_t ang_lock = g_handle_to_angular_lock[h];
+        if (ang_lock & kLockAxisX) g_handle_to_angular_vel[h].x = 0.0f;
+        if (ang_lock & kLockAxisY) g_handle_to_angular_vel[h].y = 0.0f;
+        if (ang_lock & kLockAxisZ) g_handle_to_angular_vel[h].z = 0.0f;
+    }
+
     // --- 阶段 3：为每个 mechanics 读几何/变换 → 首遇则建四元数朝向 → 预测位姿 → 世界 AABB + 长方体对角惯量（世界系冲量用）---
     std::vector<MechanicsWorldAABB> mechanics_data;
     mechanics_data.reserve(mechanics_handles.size());
@@ -1051,11 +1080,22 @@ void MechanicsSystem::update_physics() {
         ktm::fquat q_pred = g_handle_orientation_quat[h];  // 复制：预测用，不提前改全局缓存
         Corona::ModelTransform t_collision = t;            // 复制当前变换
         if (!g_handle_to_sleeping[h]) {
-            const ktm::fvec3& vc = g_handle_to_velocity[h];  // 引用线速度
+            // 为碰撞预测外推位姿时也遵守轴锁定
+            ktm::fvec3 vc = g_handle_to_velocity[h];
+            ktm::fvec3 ang_pred = g_handle_to_angular_vel[h];
+            uint8_t lin_lock = g_handle_to_linear_lock[h];
+            uint8_t ang_lock = g_handle_to_angular_lock[h];
+            if (lin_lock & kLockAxisX) vc.x = 0.0f;
+            if (lin_lock & kLockAxisY) vc.y = 0.0f;
+            if (lin_lock & kLockAxisZ) vc.z = 0.0f;
+            if (ang_lock & kLockAxisX) ang_pred.x = 0.0f;
+            if (ang_lock & kLockAxisY) ang_pred.y = 0.0f;
+            if (ang_lock & kLockAxisZ) ang_pred.z = 0.0f;
+
             t_collision.position.x += vc.x * fixed_dt;       // 外推平移用于碰撞检测
             t_collision.position.y += vc.y * fixed_dt;
             t_collision.position.z += vc.z * fixed_dt;
-            integrate_orientation_quat(q_pred, g_handle_to_angular_vel[h], fixed_dt);  // 外推旋转
+            integrate_orientation_quat(q_pred, ang_pred, fixed_dt);  // 外推旋转
         }
         sync_euler_from_orientation_quat(q_pred, t_collision.euler_rotation);  // 矩阵一致化 euler
         world_aabb_from_local_bounds(t_collision, entry.local_min, entry.local_max,
@@ -1638,6 +1678,20 @@ void MechanicsSystem::update_physics() {
         g_prev_active_collisions.clear();
     }
 
+    // --- 阶段 5b：轴锁定强制执行 — 碰撞冲量求解后，再次清零锁定轴的速度分量 ---
+    for (std::uintptr_t h : mechanics_handles) {
+        if (g_handle_to_sleeping[h]) continue;
+        uint8_t lin_lock = g_handle_to_linear_lock[h];
+        if (lin_lock & kLockAxisX) g_handle_to_velocity[h].x = 0.0f;
+        if (lin_lock & kLockAxisY) g_handle_to_velocity[h].y = 0.0f;
+        if (lin_lock & kLockAxisZ) g_handle_to_velocity[h].z = 0.0f;
+
+        uint8_t ang_lock = g_handle_to_angular_lock[h];
+        if (ang_lock & kLockAxisX) g_handle_to_angular_vel[h].x = 0.0f;
+        if (ang_lock & kLockAxisY) g_handle_to_angular_vel[h].y = 0.0f;
+        if (ang_lock & kLockAxisZ) g_handle_to_angular_vel[h].z = 0.0f;
+    }
+
     // --- 阶段 6：半隐式位姿积分（用冲量后的 v,ω）+ 无穷地板 + 休眠累计 + 缓存淘汰 ---
     for (std::size_t i = 0; i < mechanics_data.size(); ++i) {
         if (g_shutdown_requested.load(std::memory_order_acquire)) {
@@ -1653,17 +1707,28 @@ void MechanicsSystem::update_physics() {
         auto tx_w = transform_storage.try_acquire_write(data.transform_handle);
         if (!tx_w) continue;
 
+        // 为轴锁定准备一份清零后的速度副本（用于积分，不修改全局缓存）
+        ktm::fvec3 vel_for_pos = g_handle_to_velocity[h];
+        uint8_t lin_lock = g_handle_to_linear_lock[h];
+        if (lin_lock & kLockAxisX) vel_for_pos.x = 0.0f;
+        if (lin_lock & kLockAxisY) vel_for_pos.y = 0.0f;
+        if (lin_lock & kLockAxisZ) vel_for_pos.z = 0.0f;
+
         // 速度 × dt 平移（显式欧拉；与阶段 3 预测一致）
-        tx_w->position.x += g_handle_to_velocity[h].x * fixed_dt;
-        tx_w->position.y += g_handle_to_velocity[h].y * fixed_dt;
-        tx_w->position.z += g_handle_to_velocity[h].z * fixed_dt;
+        tx_w->position.x += vel_for_pos.x * fixed_dt;
+        tx_w->position.y += vel_for_pos.y * fixed_dt;
+        tx_w->position.z += vel_for_pos.z * fixed_dt;
 
         // 应用 Phase 5 累积的位置校正（积分后统一应用，避免校正与积分不一致导致抖动）
         auto corr_it = position_correction.find(h);
         if (corr_it != position_correction.end()) {
-            tx_w->position.x += corr_it->second.x;
-            tx_w->position.y += corr_it->second.y;
-            tx_w->position.z += corr_it->second.z;
+            ktm::fvec3 corr = corr_it->second;
+            if (lin_lock & kLockAxisX) corr.x = 0.0f;
+            if (lin_lock & kLockAxisY) corr.y = 0.0f;
+            if (lin_lock & kLockAxisZ) corr.z = 0.0f;
+            tx_w->position.x += corr.x;
+            tx_w->position.y += corr.y;
+            tx_w->position.z += corr.z;
         }
 
         {  // 朝向：以四元数为真值源，欧拉仅用于与渲染/资产管线对齐
@@ -1671,15 +1736,21 @@ void MechanicsSystem::update_physics() {
             if (q_it == g_handle_orientation_quat.end()) {
                 q_it = g_handle_orientation_quat.emplace(h, quat_from_model_euler(tx_w->euler_rotation)).first;
             }
-            integrate_orientation_quat(q_it->second, g_handle_to_angular_vel[h], fixed_dt);  // q ← q ⊗ Δq(ω)
+            // 为轴锁定准备一份清零后的角速度副本（用于积分，不修改全局缓存）
+            ktm::fvec3 ang_for_rot = g_handle_to_angular_vel[h];
+            uint8_t ang_lock = g_handle_to_angular_lock[h];
+            if (ang_lock & kLockAxisX) ang_for_rot.x = 0.0f;
+            if (ang_lock & kLockAxisY) ang_for_rot.y = 0.0f;
+            if (ang_lock & kLockAxisZ) ang_for_rot.z = 0.0f;
+            integrate_orientation_quat(q_it->second, ang_for_rot, fixed_dt);  // q ← q ⊗ Δq(ω)
             sync_euler_from_orientation_quat(q_it->second, tx_w->euler_rotation);            // 写回 XYZ 欧拉（约定与引擎一致）
         }
 
         // 复用 Phase 3 已计算的世界 AABB min.y，避免重新计算完整 world AABB
         // 积分后 position 偏移量与 Phase 3 的预测一致，因此可直接复用
         float object_bottom_y = data.min_world.y;
-        // 若有位置校正，补偿底面高度
-        if (corr_it != position_correction.end()) {
+        // 若有位置校正，补偿底面高度（仅在 Y 轴未锁时考虑校正）
+        if (corr_it != position_correction.end() && !(lin_lock & kLockAxisY)) {
             object_bottom_y += corr_it->second.y;
         }
 
@@ -1691,27 +1762,38 @@ void MechanicsSystem::update_physics() {
         }
 
         // 水平 floor_y：穿插时整体上抬，并做法向/切向「处方」（非完整接触流形）
+        // 轴锁定：地板碰撞的各轴修正仅在对应轴未锁时执行
         if (collision_enabled && object_bottom_y < floor_y + floor_eps) {
-            tx_w->position.y += (floor_y + floor_eps) - object_bottom_y;  // 消穿（单轴，近似静接触）
-
-            float y_vel = g_handle_to_velocity[h].y;  // 向上为正
-            if (y_vel < -low_vel_threshold) {
-                g_handle_to_velocity[h].y = -y_vel * floor_restitution;  // 下行且够快则反弹
-                g_handle_to_sleep_timer[h] = 0.0f;                       // 显著弹跳才打断休眠计时
-            } else {
-                if (std::abs(g_handle_to_velocity[h].y) < zero_vel_threshold) {
-                    g_handle_to_velocity[h].y = 0.0f;  // 粘地：贴住时竖直速度清零
-                } else {
-                    g_handle_to_velocity[h].y *= 0.15f;  // 弱弹簧感衰减残余弹跳
-                }
-
-                g_handle_to_velocity[h].x *= 0.8f;  // 水平滑动摩擦（与对体摩擦系数独立，属地板启发式）
-                g_handle_to_velocity[h].z *= 0.8f;
-                g_handle_to_angular_vel[h].x *= 0.7f;  // 滚阻：略拖慢角速度防永转
-                g_handle_to_angular_vel[h].y *= 0.7f;
-                g_handle_to_angular_vel[h].z *= 0.7f;
-                // 静接触不打断休眠计时，让休眠检测正常累积
+            // 消穿修正仅在 Y 轴未锁时执行
+            if (!(lin_lock & kLockAxisY)) {
+                tx_w->position.y += (floor_y + floor_eps) - object_bottom_y;
             }
+
+            // 法向速度反弹仅在 Y 轴未锁时处理
+            if (!(lin_lock & kLockAxisY)) {
+                float y_vel = g_handle_to_velocity[h].y;  // 向上为正
+                if (y_vel < -low_vel_threshold) {
+                    g_handle_to_velocity[h].y = -y_vel * floor_restitution;  // 下行且够快则反弹
+                    g_handle_to_sleep_timer[h] = 0.0f;                       // 显著弹跳才打断休眠计时
+                } else {
+                    if (std::abs(g_handle_to_velocity[h].y) < zero_vel_threshold) {
+                        g_handle_to_velocity[h].y = 0.0f;  // 粘地：贴住时竖直速度清零
+                    } else {
+                        g_handle_to_velocity[h].y *= 0.15f;  // 弱弹簧感衰减残余弹跳
+                    }
+                }
+            }
+
+            // 地板摩擦力仅在对应轴未锁时应用
+            if (!(lin_lock & kLockAxisX)) g_handle_to_velocity[h].x *= 0.8f;
+            if (!(lin_lock & kLockAxisZ)) g_handle_to_velocity[h].z *= 0.8f;
+
+            // 滚阻仅在对应轴未锁时应用
+            uint8_t ang_lock = g_handle_to_angular_lock[h];
+            if (!(ang_lock & kLockAxisX)) g_handle_to_angular_vel[h].x *= 0.7f;
+            if (!(ang_lock & kLockAxisY)) g_handle_to_angular_vel[h].y *= 0.7f;
+            if (!(ang_lock & kLockAxisZ)) g_handle_to_angular_vel[h].z *= 0.7f;
+            // 静接触不打断休眠计时，让休眠检测正常累积
         }
     }
 
@@ -1830,6 +1912,8 @@ void MechanicsSystem::update_physics() {
 
     clean_cache(g_handle_to_sleeping);
     clean_cache(g_handle_to_sleep_timer);
+    clean_cache(g_handle_to_linear_lock);
+    clean_cache(g_handle_to_angular_lock);
     clean_cache(handle_to_mass);
     clean_cache(handle_to_damping);
     clean_cache(handle_to_restitution);

--- a/src/systems/script/python/corona_engine_api.cpp
+++ b/src/systems/script/python/corona_engine_api.cpp
@@ -1190,6 +1190,52 @@ bool Corona::API::Mechanics::get_collision_enabled() const {
     return true;
 }
 
+void Corona::API::Mechanics::set_linear_lock(bool lock_x, bool lock_y, bool lock_z) {
+    if (handle_ == 0) {
+        CFW_LOG_WARNING("[Mechanics::set_linear_lock] Invalid mechanics handle");
+        return;
+    }
+    if (auto accessor = SharedDataHub::instance().mechanics_storage().acquire_write(handle_)) {
+        uint8_t mask = 0;
+        if (lock_x) mask |= 0b001;
+        if (lock_y) mask |= 0b010;
+        if (lock_z) mask |= 0b100;
+        accessor->linear_lock_mask = mask;
+    }
+}
+
+std::tuple<bool, bool, bool> Corona::API::Mechanics::get_linear_lock() const {
+    if (handle_ == 0) return {false, false, false};
+    if (auto accessor = SharedDataHub::instance().mechanics_storage().try_acquire_read(handle_)) {
+        uint8_t mask = accessor->linear_lock_mask;
+        return {(mask & 0b001) != 0, (mask & 0b010) != 0, (mask & 0b100) != 0};
+    }
+    return {false, false, false};
+}
+
+void Corona::API::Mechanics::set_angular_lock(bool lock_x, bool lock_y, bool lock_z) {
+    if (handle_ == 0) {
+        CFW_LOG_WARNING("[Mechanics::set_angular_lock] Invalid mechanics handle");
+        return;
+    }
+    if (auto accessor = SharedDataHub::instance().mechanics_storage().acquire_write(handle_)) {
+        uint8_t mask = 0;
+        if (lock_x) mask |= 0b001;
+        if (lock_y) mask |= 0b010;
+        if (lock_z) mask |= 0b100;
+        accessor->angular_lock_mask = mask;
+    }
+}
+
+std::tuple<bool, bool, bool> Corona::API::Mechanics::get_angular_lock() const {
+    if (handle_ == 0) return {false, false, false};
+    if (auto accessor = SharedDataHub::instance().mechanics_storage().try_acquire_read(handle_)) {
+        uint8_t mask = accessor->angular_lock_mask;
+        return {(mask & 0b001) != 0, (mask & 0b010) != 0, (mask & 0b100) != 0};
+    }
+    return {false, false, false};
+}
+
 void Corona::API::Mechanics::set_collision_callback(
     std::function<void(std::uintptr_t, bool, const std::array<float, 3>&, const std::array<float, 3>&)> callback) {
     if (handle_ == 0) {

--- a/src/systems/script/python/engine_bindings.cpp
+++ b/src/systems/script/python/engine_bindings.cpp
@@ -82,6 +82,16 @@ void BindAll(nanobind::module_& m) {
              "Enable or disable collision detection for this object")
         .def("get_collision_enabled", &Mechanics::get_collision_enabled,
              "Get whether collision detection is enabled for this object")
+        .def("set_linear_lock", &Mechanics::set_linear_lock,
+             nb::arg("lock_x"), nb::arg("lock_y"), nb::arg("lock_z"),
+             "Lock/unlock linear movement on X/Y/Z axes")
+        .def("get_linear_lock", &Mechanics::get_linear_lock,
+             "Get linear axis lock state as (lock_x, lock_y, lock_z) tuple")
+        .def("set_angular_lock", &Mechanics::set_angular_lock,
+             nb::arg("lock_x"), nb::arg("lock_y"), nb::arg("lock_z"),
+             "Lock/unlock angular rotation on X/Y/Z axes")
+        .def("get_angular_lock", &Mechanics::get_angular_lock,
+             "Get angular axis lock state as (lock_x, lock_y, lock_z) tuple")
         .def("set_collision_callback",
              [](Mechanics& self, nb::object callback) {
                  using CallbackType = std::function<void(std::uintptr_t, bool, const std::array<float, 3>&, const std::array<float, 3>&)>;

--- a/src/systems/ui/cef/cef_realtime_bridge.cpp
+++ b/src/systems/ui/cef/cef_realtime_bridge.cpp
@@ -354,6 +354,20 @@ bool handle_property_fast(const CefRefPtr<CefProcessMessage>& message) {
                     }
                 }
                 break;
+            case 6:  // LinearLockMask (bit0=X, bit1=Y, bit2=Z)
+                if (profile->mechanics_handle != 0) {
+                    if (auto mech = hub.mechanics_storage().try_acquire_write(profile->mechanics_handle)) {
+                        mech->linear_lock_mask = static_cast<uint8_t>(value);
+                    }
+                }
+                break;
+            case 7:  // AngularLockMask (bit0=X, bit1=Y, bit2=Z)
+                if (profile->mechanics_handle != 0) {
+                    if (auto mech = hub.mechanics_storage().try_acquire_write(profile->mechanics_handle)) {
+                        mech->angular_lock_mask = static_cast<uint8_t>(value);
+                    }
+                }
+                break;
             default:
                 CFW_LOG_WARNING("PropertyFast: unknown propertyType {}", property_type);
                 break;


### PR DESCRIPTION
corona_engine_scratch.py 为线程上下文运行时，支持 project/global 与 actor 脚本并行。
ScratchTool 的保存/加载、manifest、多目标预览、停止恢复快照。
proejct_utils.py 的 pending auto-save flush/cancel，这是恢复预览前状态的必要依赖。
Blockly 目标保存/加载、全局 hooks、预览开始/结束按钮和 bridge 方法。