### PR TITLE
实现物体减面动态选择lod，修复bug

### DIFF
--- a/include/corona/systems/geometry/geometry_system.h
+++ b/include/corona/systems/geometry/geometry_system.h
@@ -79,25 +79,6 @@ struct SceneStats {
 /**
  * @brief 单个 LOD 级别的 GPU 缓冲集合
  *
- * 【这是什么】
- * 一个 LOD 级别在 GPU 端需要的全部缓冲。
- * 引擎渲染时用这些缓冲来实际绘制模型。
- *
- * 【为什么需要 4 个缓冲】
- * - vertex_buffer：顶点数据缓冲（位置+法线+UV），用于顶点着色器读取
- * - index_buffer：索引缓冲，告诉 GPU 哪三个顶点组成一个三角形
- * - vertex_storage：顶点数据的 StorageBuffer 版本，用于 Compute Shader
- *   （某些渲染管线需要从 Compute Shader 中访问顶点数据做 GPU 端处理）
- * - index_storage：同上，索引的 StorageBuffer 版本
- *
- * 【ready 标志】
- * GPU 缓冲的创建必须在主线程完成（Horizon 框架的限制）。
- * 异步简化完成后，下一帧主线程会创建缓冲并把 ready 设为 true。
- * 渲染时如果 ready=false（还没准备好），会降级使用 LOD 0（原始网格）。
- *
- * 【screen_threshold】
- * 当物体在屏幕上的占比低于此阈值时，切换到该 LOD 级别。
- * 例如 threshold=0.25 意味着物体占屏幕不到 25% 时就换用这个低模。
  */
 struct LODMeshBuffers {
     HardwareBuffer vertex_buffer;    // GPU 顶点缓冲（Vertex Shader 读取）

--- a/include/corona/systems/geometry/geometry_system.h
+++ b/include/corona/systems/geometry/geometry_system.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Horizon.h>
+
 #include <corona/events/geometry_system_events.h>
 #include <corona/events/scene_system_events.h>
 #include <corona/kernel/event/i_event_bus.h>
@@ -9,9 +11,7 @@
 #include <corona/spatial/aabb.h>
 
 #include <cstdint>
-#include <future>
 #include <memory>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -59,6 +59,69 @@ struct SceneStats {
     std::size_t actor_unloaded    = 0;
 };
 
+// ========================================
+// 动态减面 (Mesh Simplification) 相关类型
+// ========================================
+//
+// 网格简化由资源导入管线完成（使用 meshoptimizer 库，参见
+// modules/corona_resource 中的 parse_common.h）。
+// 导入时已生成多级 LOD 数据（MeshData::lod_levels），
+// 本系统负责：
+//   1. 将导入时生成的 CPU 端 LOD 数据上传为 GPU 缓冲（upload_lod_from_scene_data）
+//   2. 提供线程安全的 LOD 查询接口供渲染线程使用
+//   3. 根据屏幕占比自动选择合适的 LOD 级别
+//
+// 数据流向：
+//   导入时 meshoptimizer → MeshData::lod_levels [CPU]
+//   → upload_lod_from_scene_data() → LODMeshBuffers [GPU] → 存入 lod_cache
+//   → 渲染时查询 get_lod_buffers() → 替换原始缓冲 → 提交 GPU 绘制
+
+/**
+ * @brief 单个 LOD 级别的 GPU 缓冲集合
+ *
+ * 【这是什么】
+ * 一个 LOD 级别在 GPU 端需要的全部缓冲。
+ * 引擎渲染时用这些缓冲来实际绘制模型。
+ *
+ * 【为什么需要 4 个缓冲】
+ * - vertex_buffer：顶点数据缓冲（位置+法线+UV），用于顶点着色器读取
+ * - index_buffer：索引缓冲，告诉 GPU 哪三个顶点组成一个三角形
+ * - vertex_storage：顶点数据的 StorageBuffer 版本，用于 Compute Shader
+ *   （某些渲染管线需要从 Compute Shader 中访问顶点数据做 GPU 端处理）
+ * - index_storage：同上，索引的 StorageBuffer 版本
+ *
+ * 【ready 标志】
+ * GPU 缓冲的创建必须在主线程完成（Horizon 框架的限制）。
+ * 异步简化完成后，下一帧主线程会创建缓冲并把 ready 设为 true。
+ * 渲染时如果 ready=false（还没准备好），会降级使用 LOD 0（原始网格）。
+ *
+ * 【screen_threshold】
+ * 当物体在屏幕上的占比低于此阈值时，切换到该 LOD 级别。
+ * 例如 threshold=0.25 意味着物体占屏幕不到 25% 时就换用这个低模。
+ */
+struct LODMeshBuffers {
+    HardwareBuffer vertex_buffer;    // GPU 顶点缓冲（Vertex Shader 读取）
+    HardwareBuffer index_buffer;     // GPU 索引缓冲（组装三角形）
+    HardwareBuffer vertex_storage;   // GPU 顶点 StorageBuffer（Compute Shader 用）
+    HardwareBuffer index_storage;    // GPU 索引 StorageBuffer（Compute Shader 用）
+    float  error            = 0.0f;  // 该级别的几何误差（QEM 计算得出，用于调试）
+    float  screen_threshold = 1.0f;  // 屏幕占比阈值：低于此值时切换到此级别
+    bool   ready            = false; // GPU 缓冲是否已创建完毕（创建前不能用于渲染）
+};
+
+/**
+ * @brief 动态减面全局配置
+ *
+ * 控制 LOD 系统的行为。通过 set_simplification_config() 设置。
+ * 注意：具体的简化参数（target_ratios、max_errors 等）由导入时的
+ * LODGenerationOptions 控制（参见 corona/resource/types/scene.h）。
+ */
+struct MeshSimplificationConfig {
+    bool enabled      = true;   // 总开关：false 时整个 LOD 系统不工作
+    int  max_lod_levels = 4;    // 最大 LOD 级别数（含 LOD 0 原始精度）
+    bool auto_on_load = true;   // 模型加载后是否自动将导入时的 LOD 数据上传 GPU
+};
+
 /**
  * @brief 几何系统 (Geometry System)
  *
@@ -68,6 +131,7 @@ struct SceneStats {
  * - 提供线程安全的 AABB / 球 / 视锥 / 碰撞对查询；
  * - 维护 Actor 加载状态机与距离预加载/卸载；
  * - 维护 actor 可见性热度并发出 LRU evict/restore 事件。
+ * - 管理运行时 LOD 切换（基于导入时 meshoptimizer 生成的简化数据）。
  *
  * 运行在独立线程，以 60 FPS 更新几何状态。
  *
@@ -163,6 +227,76 @@ class GeometrySystem : public Kernel::SystemBase {
                                 const std::vector<float>& thresholds);
 
     // ========================================
+    // 动态减面 (Mesh Simplification) API
+    // ========================================
+    //
+    // 以下方法构成了 LOD 系统的对外接口。使用流程：
+    //
+    //   【初始化阶段】
+    //   set_simplification_config(cfg)  ← 配置 LOD 开关和最大级别数
+    //
+    //   【自动上传】
+    //   模型导入时 meshoptimizer 已生成了 LOD 数据（存在 MeshData::lod_levels）。
+    //   引擎会在 update() 中自动调用 upload_lod_from_scene_data() 将其上传 GPU。
+    //   无需手动调用任何方法。
+    //
+    //   【渲染时查询】
+    //   get_lod_buffers(geom, mesh_idx, lod) ← 获取指定级别的 GPU 缓冲句柄
+    //   resolve_lod_level(geom, mesh_idx, ...) ← 根据屏幕占比自动选择 LOD 级别
+
+    /// 设置减面全局配置
+    /// 修改会立即生效（已有缓存不受影响）
+    void set_simplification_config(const MeshSimplificationConfig& cfg);
+
+    /// 获取当前减面配置（只读）
+    [[nodiscard]] const MeshSimplificationConfig& get_simplification_config() const;
+
+    /// 查询指定 LOD 级别的 GPU 缓冲（渲染线程调用，线程安全）
+    ///
+    /// @param geometry_handle GeometryDevice 句柄
+    /// @param mesh_index      子网格索引
+    /// @param lod_level       LOD 级别（0=原始精度，1..N=各级简化）
+    /// @return 指向 LODMeshBuffers 的指针，或 nullptr 表示该级别不存在
+    ///
+    /// 降级策略：如果请求的级别尚未就绪（ready=false），自动返回 LOD 0。
+    /// 调用者无需处理未就绪的情况。
+    [[nodiscard]] const LODMeshBuffers* get_lod_buffers(
+        std::uintptr_t geometry_handle,
+        uint32_t       mesh_index,
+        int            lod_level) const;
+
+    /// 查询某个 mesh 已就绪的 LOD 级别数
+    /// @return 0 表示该 mesh 还未上传任何 LOD 数据
+    [[nodiscard]] int get_lod_count(std::uintptr_t geometry_handle,
+                                    uint32_t       mesh_index) const;
+
+    /// 一站式 LOD 级别选择：给定屏幕占比，返回应使用的 LOD 级别
+    ///
+    /// 内部流程：
+    ///   1. 从 lod_cache 获取该 mesh 的各 LOD 级别阈值
+    ///   2. 调用 select_lod_level(screen_ratio, thresholds) 选择级别
+    ///   3. 如果选中的级别未就绪，自动降级到最近的已就绪级别
+    ///
+    /// @param geometry_handle GeometryDevice 句柄
+    /// @param mesh_index      子网格索引
+    /// @param screen_ratio    物体在屏幕上的占比（0~1），由 compute_screen_ratio() 算得
+    /// @return 应使用的 LOD 级别（0=原始，1..N=各级简化）
+    [[nodiscard]] int resolve_lod_level(std::uintptr_t geometry_handle,
+                                        uint32_t       mesh_index,
+                                        float          screen_ratio) const;
+
+    /// 一站式 LOD 缓冲获取：自动选级 + 返回 GPU 缓冲（渲染线程调用，单次加锁）
+    ///
+    /// 等价于 resolve_lod_level() + get_lod_buffers()，但只获取一次锁。
+    /// 渲染热路径上应优先使用此方法。
+    ///
+    /// @return 指向 LODMeshBuffers 的指针，或 nullptr 表示该 mesh 无 LOD 数据
+    [[nodiscard]] const LODMeshBuffers* resolve_lod_buffers(
+        std::uintptr_t geometry_handle,
+        uint32_t       mesh_index,
+        float          screen_ratio) const;
+
+    // ========================================
     // 统计
     // ========================================
     [[nodiscard]] SceneStats stats(std::uintptr_t scene) const;
@@ -173,6 +307,18 @@ class GeometrySystem : public Kernel::SystemBase {
     void on_load_requested(const Events::ActorLoadRequestedEvent& event);
     void on_unload_requested(const Events::ActorUnloadRequestedEvent& event);
     void process_async_tasks();  // 处理完成的异步资源任务
+
+    // ========================================
+    // 动态减面内部管线（在 update() 中每帧调用，外部不可见）
+    // ========================================
+    //
+    // 模型导入时 meshoptimizer 已生成 LOD 数据（MeshData::lod_levels），
+    // 这里只负责将其上传为 GPU 缓冲。
+
+    /// 遍历所有已加载的 Scene 资源，
+    /// 将其 MeshData::lod_levels（导入时 meshoptimizer 生成的LOD数据）上传到 GPU。
+    /// 每帧调用但只对新模型生效（已有缓存的跳过）。
+    void upload_lod_from_scene_data();
 
     struct Impl;
     std::unique_ptr<Impl> impl_;

--- a/include/corona/systems/geometry/geometry_system.h
+++ b/include/corona/systems/geometry/geometry_system.h
@@ -308,6 +308,16 @@ class GeometrySystem : public Kernel::SystemBase {
     void on_unload_requested(const Events::ActorUnloadRequestedEvent& event);
     void process_async_tasks();  // 处理完成的异步资源任务
 
+    /// 卸载完成时释放 actor 关联的 GPU 资源（HardwareBuffer / HardwareImage），
+    /// 并清理对应的 LOD 缓存条目。不释放 SharedDataHub 存储槽位本身——
+    /// 槽位归 Python API 层 Geometry 对象所有，由其析构函数回收。
+    void release_actor_gpu_resources(std::uintptr_t actor);
+
+    /// 重新加载完成时重建 actor 关联的 GPU 资源（HardwareBuffer / HardwareImage），
+    /// 从已导入的 Scene 资源中重新创建 mesh_handles 并恢复 model_resource_handle。
+    /// 同时清理 LOD 缓存以保证下一帧 update() 重新上传 LOD 数据。
+    void rebuild_actor_gpu_resources(std::uintptr_t actor, std::uint64_t rid);
+
     // ========================================
     // 动态减面内部管线（在 update() 中每帧调用，外部不可见）
     // ========================================

--- a/include/corona/systems/optics/optics_system.h
+++ b/include/corona/systems/optics/optics_system.h
@@ -20,6 +20,8 @@ struct Hardware;
 
 namespace Corona::Systems {
 
+class GeometrySystem;  // 前向声明，用于 LOD 查询
+
 #ifdef CORONA_ENABLE_VISION
 namespace Vision {
 struct VisionBuildResult;  // 定义见 vision/vision_geometry_adapter.h
@@ -162,6 +164,10 @@ class OpticsSystem : public Kernel::SystemBase {
     uint32_t offscreen_w_{0}, offscreen_h_{0};
 
     std::unique_ptr<Hardware> hardware_;
+
+    // LOD 系统引用（渲染时查询 LOD 缓冲）
+    GeometrySystem* geometry_system_ = nullptr;
+    bool geometry_system_queried_ = false;  // 避免每帧重试失败的获取
 
     // Vision 后端状态
 #ifdef CORONA_ENABLE_VISION

--- a/include/corona/systems/script/corona_engine_api.h
+++ b/include/corona/systems/script/corona_engine_api.h
@@ -44,6 +44,9 @@ class Geometry {
     /// 获取模型 AABB，返回 {min_x, min_y, min_z, max_x, max_y, max_z}
     [[nodiscard]] std::array<float, 6> get_aabb() const;
 
+    /// 获取构造时传入的模型文件路径，用于 Actor 身份标识和资源加载/卸载
+    [[nodiscard]] const std::filesystem::path& get_model_path() const;
+
    private:
     friend class Mechanics;
     friend class Optics;
@@ -58,6 +61,7 @@ class Geometry {
     std::uintptr_t handle_{};
     std::uintptr_t transform_handle_{};
     std::uintptr_t model_resource_handle_{};
+    std::filesystem::path model_path_;
 };
 
 // ============================================================================

--- a/modules/corona_resource/src/resource/types/parse_common.h
+++ b/modules/corona_resource/src/resource/types/parse_common.h
@@ -1090,7 +1090,8 @@ inline std::vector<LODLevel> generate_lod_levels(
         level.indices = std::move(final_indices);
         level.error = result_error;
         // 屏幕阈值：误差越大，阈值越小（越远才使用）
-        level.screen_threshold = (result_error > 0.0f) ? std::min(1.0f, result_error * 10.0f) : 0.0f;
+        // 使用反比公式：error 越大 → threshold 越小 → 只在屏幕占比更小时选中此 LOD
+        level.screen_threshold = (result_error > 0.0f) ? std::max(0.01f, 1.0f / (1.0f + result_error * 80.0f)) : 0.0f;
 
         (void)mesh_name;
         (void)ratio;

--- a/src/systems/geometry/geometry_internal.h
+++ b/src/systems/geometry/geometry_internal.h
@@ -99,6 +99,23 @@ struct GeometrySystem::Impl {
     std::vector<Kernel::EventId>                            event_subscriptions;
     Kernel::ISystemContext*                                 ctx = nullptr;
 
+    // ========================================
+    // 动态减面（LOD）相关状态
+    // ========================================
+    struct LODCacheEntry {
+        std::vector<LODMeshBuffers> levels;
+        std::uintptr_t model_resource_handle = 0;  // 用于检测模型变更（slot 复用）
+    };
+
+    MeshSimplificationConfig           simplification_cfg;
+    mutable std::shared_mutex          lod_cache_mutex;
+    std::unordered_map<uint64_t, LODCacheEntry> lod_cache;
+
+    [[nodiscard]] static uint64_t make_lod_key(std::uintptr_t geometry_handle,
+                                               uint32_t       mesh_index) {
+        return (static_cast<uint64_t>(geometry_handle) << 32) | mesh_index;
+    }
+
     SceneState& get_or_create(std::uintptr_t scene) {
         auto [it, inserted] = scenes.try_emplace(scene);
         return it->second;

--- a/src/systems/geometry/geometry_internal.h
+++ b/src/systems/geometry/geometry_internal.h
@@ -104,12 +104,16 @@ struct GeometrySystem::Impl {
     // ========================================
     struct LODCacheEntry {
         std::vector<LODMeshBuffers> levels;
-        std::uintptr_t model_resource_handle = 0;  // 用于检测模型变更（slot 复用）
+        std::uint64_t model_id = 0;  // 用于检测模型变更（比地址指针可靠，不受 slot 复用影响）
     };
 
     MeshSimplificationConfig           simplification_cfg;
     mutable std::shared_mutex          lod_cache_mutex;
     std::unordered_map<uint64_t, LODCacheEntry> lod_cache;
+
+    // 共享占位纹理：所有无纹理 mesh 共用，生命周期与 Impl 一致
+    // 使用 unique_ptr 避免 static 局部变量在 GPU device 析构后才析构
+    std::unique_ptr<HardwareImage>      shared_placeholder_texture;
 
     [[nodiscard]] static uint64_t make_lod_key(std::uintptr_t geometry_handle,
                                                uint32_t       mesh_index) {

--- a/src/systems/geometry/geometry_system.cpp
+++ b/src/systems/geometry/geometry_system.cpp
@@ -20,6 +20,7 @@
 
 #include <corona/resource/resource.h>
 #include <corona/resource/resource_manager.h>
+#include <corona/resource/types/scene.h>
 
 #include "geometry_internal.h"
 
@@ -80,6 +81,11 @@ void GeometrySystem::update() {
     }
 
     process_async_tasks();
+
+    // ---- 动态减面管线 ----
+    if (impl_->simplification_cfg.enabled) {
+        upload_lod_from_scene_data();
+    }
 
     for (std::uintptr_t scene_handle : scene_handles) {
         const auto scene_begin = std::chrono::steady_clock::now();
@@ -747,6 +753,191 @@ void GeometrySystem::on_unload_requested(const Events::ActorUnloadRequestedEvent
                   e.actor, Utils::path_to_utf8(actor_read->model_path));
     scene_state.unload_retry_counts[e.actor] = 0;
     scene_state.unloading_tasks[e.actor] = Resource::ResourceManager::get_instance().remove_cache_async(rid);
+}
+
+// ============================================================================
+// 动态减面 (Mesh Simplification) 公共 API
+// ============================================================================
+
+void GeometrySystem::set_simplification_config(const MeshSimplificationConfig& cfg) {
+    impl_->simplification_cfg = cfg;
+}
+
+const MeshSimplificationConfig& GeometrySystem::get_simplification_config() const {
+    return impl_->simplification_cfg;
+}
+
+const LODMeshBuffers* GeometrySystem::get_lod_buffers(
+    std::uintptr_t geometry_handle,
+    uint32_t       mesh_index,
+    int            lod_level) const {
+
+    std::shared_lock lock(impl_->lod_cache_mutex);
+    auto key = Impl::make_lod_key(geometry_handle, mesh_index);
+    auto it = impl_->lod_cache.find(key);
+    if (it == impl_->lod_cache.end()) return nullptr;
+    if (lod_level < 0 || static_cast<size_t>(lod_level) >= it->second.levels.size())
+        return nullptr;
+    auto& level = it->second.levels[lod_level];
+    // 降级：如果目标级别未就绪，回退到 LOD 0
+    if (!level.ready && lod_level > 0) {
+        auto& lod0 = it->second.levels[0];
+        return lod0.ready ? &lod0 : nullptr;
+    }
+    return level.ready ? &level : nullptr;
+}
+
+int GeometrySystem::get_lod_count(std::uintptr_t geometry_handle,
+                                  uint32_t       mesh_index) const {
+    std::shared_lock lock(impl_->lod_cache_mutex);
+    auto key = Impl::make_lod_key(geometry_handle, mesh_index);
+    auto it = impl_->lod_cache.find(key);
+    if (it == impl_->lod_cache.end()) return 0;
+    return static_cast<int>(it->second.levels.size());
+}
+
+int GeometrySystem::resolve_lod_level(std::uintptr_t geometry_handle,
+                                      uint32_t       mesh_index,
+                                      float          screen_ratio) const {
+
+    std::shared_lock lock(impl_->lod_cache_mutex);
+    auto key = Impl::make_lod_key(geometry_handle, mesh_index);
+    auto it = impl_->lod_cache.find(key);
+    if (it == impl_->lod_cache.end()) return 0;
+
+    std::vector<float> thresholds;
+    for (size_t i = 1; i < it->second.levels.size(); ++i) {
+        thresholds.push_back(it->second.levels[i].screen_threshold);
+    }
+
+    int selected = select_lod_level(screen_ratio, thresholds);
+
+    // 降级到最近的已就绪级别
+    while (selected > 0) {
+        if (static_cast<size_t>(selected) < it->second.levels.size()
+            && it->second.levels[selected].ready)
+            break;
+        selected--;
+    }
+    return selected;
+}
+
+const LODMeshBuffers* GeometrySystem::resolve_lod_buffers(
+    std::uintptr_t geometry_handle,
+    uint32_t       mesh_index,
+    float          screen_ratio) const {
+
+    std::shared_lock lock(impl_->lod_cache_mutex);
+    auto key = Impl::make_lod_key(geometry_handle, mesh_index);
+    auto it = impl_->lod_cache.find(key);
+    if (it == impl_->lod_cache.end()) return nullptr;
+
+    // 构建阈值列表（LOD 1..N 的 screen_threshold）
+    std::vector<float> thresholds;
+    for (size_t i = 1; i < it->second.levels.size(); ++i) {
+        thresholds.push_back(it->second.levels[i].screen_threshold);
+    }
+
+    int selected = select_lod_level(screen_ratio, thresholds);
+
+    // 降级到最近的已就绪级别
+    while (selected > 0) {
+        if (static_cast<size_t>(selected) < it->second.levels.size()
+            && it->second.levels[selected].ready)
+            break;
+        selected--;
+    }
+
+    // 返回缓冲（与 get_lod_buffers 相同的降级策略）
+    if (selected < 0 || static_cast<size_t>(selected) >= it->second.levels.size())
+        return nullptr;
+
+    auto& level = it->second.levels[selected];
+    if (!level.ready && selected > 0) {
+        auto& lod0 = it->second.levels[0];
+        return lod0.ready ? &lod0 : nullptr;
+    }
+    return level.ready ? &level : nullptr;
+}
+
+// ============================================================================
+// 动态减面内部管线
+// ============================================================================
+
+void GeometrySystem::upload_lod_from_scene_data() {
+    if (!impl_->simplification_cfg.auto_on_load) return;
+
+    auto& resource_manager = Resource::ResourceManager::get_instance();
+    auto& geom_storage = SharedDataHub::instance().geometry_storage();
+
+    for (auto it = geom_storage.cbegin(); it != geom_storage.cend(); ++it) {
+        const GeometryDevice& geom_dev = *it;
+        auto geom_handle = reinterpret_cast<std::uintptr_t>(&geom_dev);
+        if (!geom_dev.model_resource_handle) continue;
+
+        for (uint32_t mesh_idx = 0; mesh_idx < static_cast<uint32_t>(geom_dev.mesh_handles.size()); ++mesh_idx) {
+            uint64_t lod_key = Impl::make_lod_key(geom_handle, mesh_idx);
+
+            // 已有缓存且模型未变更则跳过（model_resource_handle 比较防止 slot 复用）
+            {
+                std::shared_lock lock(impl_->lod_cache_mutex);
+                auto cache_it = impl_->lod_cache.find(lod_key);
+                if (cache_it != impl_->lod_cache.end()
+                    && cache_it->second.model_resource_handle == geom_dev.model_resource_handle)
+                    continue;
+            }
+
+            // 从 ResourceManager 读取 Scene 数据
+            auto scene_read = resource_manager.acquire_read<Resource::Scene>(geom_dev.model_resource_handle);
+            if (!scene_read.valid()) continue;
+
+            auto& scene = *scene_read;
+            if (mesh_idx >= scene.data.meshes.size()) continue;
+
+            auto& mesh = scene.data.meshes[mesh_idx];
+            if (mesh.lod_levels.empty()) continue;
+
+            // 创建缓存条目
+            Impl::LODCacheEntry entry;
+            entry.model_resource_handle = geom_dev.model_resource_handle;
+            auto& mesh_dev = geom_dev.mesh_handles[mesh_idx];
+
+            // LOD 0：复用现有的 GPU 缓冲
+            LODMeshBuffers lod0;
+            lod0.vertex_buffer    = mesh_dev.vertexBuffer;
+            lod0.index_buffer     = mesh_dev.indexBuffer;
+            lod0.vertex_storage   = mesh_dev.vertexStorageBuffer;
+            lod0.index_storage    = mesh_dev.indexStorageBuffer;
+            lod0.error            = 0.0f;
+            lod0.screen_threshold = 1.0f;
+            lod0.ready            = true;
+            entry.levels.push_back(std::move(lod0));
+
+            // LOD 1..N：从导入时 meshoptimizer 生成的数据创建 GPU 缓冲
+            for (size_t lod_idx = 0; lod_idx < mesh.lod_levels.size() && lod_idx < static_cast<size_t>(impl_->simplification_cfg.max_lod_levels - 1); ++lod_idx) {
+                auto& lod_data = mesh.lod_levels[lod_idx];
+                if (lod_data.vertices.empty() || lod_data.indices.empty()) continue;
+
+                LODMeshBuffers lod_buf;
+                // 转换为 uint32 索引（meshopt 输出 uint16，GPU 需要 uint32）
+                std::vector<uint32_t> indices32;
+                indices32.reserve(lod_data.indices.size());
+                for (auto idx : lod_data.indices) indices32.push_back(static_cast<uint32_t>(idx));
+
+                lod_buf.vertex_buffer    = HardwareBuffer(lod_data.vertices, BufferUsage::VertexBuffer);
+                lod_buf.index_buffer     = HardwareBuffer(indices32,        BufferUsage::IndexBuffer);
+                lod_buf.vertex_storage   = HardwareBuffer(lod_data.vertices, BufferUsage::StorageBuffer);
+                lod_buf.index_storage    = HardwareBuffer(indices32,        BufferUsage::StorageBuffer);
+                lod_buf.error            = lod_data.error;
+                lod_buf.screen_threshold = lod_data.screen_threshold;
+                lod_buf.ready            = true;
+                entry.levels.push_back(std::move(lod_buf));
+            }
+
+            std::unique_lock lock(impl_->lod_cache_mutex);
+            impl_->lod_cache.insert_or_assign(lod_key, std::move(entry));
+        }
+    }
 }
 
 }  // namespace Corona::Systems

--- a/src/systems/geometry/geometry_system.cpp
+++ b/src/systems/geometry/geometry_system.cpp
@@ -83,7 +83,13 @@ void GeometrySystem::update() {
     process_async_tasks();
 
     // ---- 动态减面管线 ----
-    if (impl_->simplification_cfg.enabled) {
+    // 用 shared_lock 快照 simplification_cfg，与 set_simplification_config 的 unique_lock 互斥
+    bool run_simplification = false;
+    {
+        std::shared_lock lock(impl_->mtx);
+        run_simplification = impl_->simplification_cfg.enabled;
+    }
+    if (run_simplification) {
         upload_lod_from_scene_data();
     }
 
@@ -449,6 +455,9 @@ void GeometrySystem::shutdown() {
 
     impl_->scenes.clear();
     impl_->offline_actors.clear();
+
+    // 显式释放共享占位纹理，确保在 GPU device 仍存活时析构 HardwareImage
+    impl_->shared_placeholder_texture.reset();
 }
 
 // ============================================================================
@@ -760,10 +769,9 @@ void GeometrySystem::rebuild_actor_gpu_resources(std::uintptr_t actor, std::uint
 
             // ---- 创建共享的 1x1 白色占位纹理 ----
             // 用于无纹理的 mesh，确保渲染管线始终有纹理可采样
-            // static → 全局唯一，所有无纹理 mesh 共享同一张（节省显存）
-            // lambda 立即执行 → 程序启动时构造一次
-            static HardwareImage shared_placeholder_texture = []() {
-                // 构造 1×1 像素、RGBA8 sRGB 格式的纹理创建信息
+            // 生命周期由 Impl::shared_placeholder_texture 管理，shutdown() 中显式释放
+            // 避免 static 局部变量在 GPU device 析构后才析构导致 crash
+            if (!impl_->shared_placeholder_texture) {
                 HardwareImageCreateInfo placeholder_info{};
                 placeholder_info.width        = 1;                       // 1 像素宽
                 placeholder_info.height       = 1;                       // 1 像素高
@@ -773,12 +781,12 @@ void GeometrySystem::rebuild_actor_gpu_resources(std::uintptr_t actor, std::uint
                 placeholder_info.mipLevels    = 1;                       // 无 mipmap
 
                 static const unsigned char white_pixel[4] = {255, 255, 255, 255};  // 不透明白色
-                HardwareImage texture(placeholder_info);               // 创建 GPU 纹理对象
+                impl_->shared_placeholder_texture = std::make_unique<HardwareImage>(placeholder_info);
                 HardwareExecutor temp_executor;                        // 临时命令执行器
                 // 将白色像素数据拷贝到 GPU 纹理，提交执行
-                temp_executor << texture.copyFrom(white_pixel) << temp_executor.commit();
-                return texture;  // 返回创建好的纹理（move 语义）
-            }();
+                temp_executor << impl_->shared_placeholder_texture->copyFrom(white_pixel)
+                              << temp_executor.commit();
+            }
 
             // ---- 第一阶段：遍历所有 mesh，创建 GPU 缓冲 ----
             for (std::uint32_t mesh_idx = 0; mesh_idx < scene.data.meshes.size(); ++mesh_idx) {
@@ -917,7 +925,7 @@ void GeometrySystem::rebuild_actor_gpu_resources(std::uintptr_t actor, std::uint
                 // ---- 无纹理的兜底：使用共享白色占位纹理 ----
                 // 确保每个 mesh 都有纹理句柄，避免渲染时空指针
                 if (!texture_created) {
-                    dev.textureBuffer = shared_placeholder_texture;  // 拷贝共享纹理句柄
+                    dev.textureBuffer = *impl_->shared_placeholder_texture;  // 拷贝共享纹理句柄
                 }
 
                 // ---- 将构建好的 MeshDevice 加入数组 ----
@@ -1045,6 +1053,20 @@ void GeometrySystem::process_async_tasks() {
     }
 
     for (const auto& task : completed_loads) {
+        // 检查加载是否已被 on_unload_requested 取消（状态被改为非 Loading）
+        {
+            std::shared_lock lock(impl_->mtx);
+            auto scene_it = impl_->scenes.find(task.scene_handle);
+            if (scene_it != impl_->scenes.end()) {
+                auto state_it = scene_it->second.actor_load_states.find(task.actor);
+                if (state_it == scene_it->second.actor_load_states.end() ||
+                    state_it->second != ActorLoadState::Loading) {
+                    CFW_LOG_DEBUG("[SceneSystem] Actor {} load completed but was cancelled — skipping", task.actor);
+                    continue;
+                }
+            }
+        }
+
         if (task.rid != Resource::IResource::INVALID_UID) {
             // 重建 GPU 资源（mesh_handles + 纹理），恢复 model_resource_handle
             // 必须在发布 ActorLoadCompletedEvent 之前完成，
@@ -1110,11 +1132,10 @@ void GeometrySystem::process_async_tasks() {
                                (unsigned long)task.actor, retry_count + 1);
 
                 if (++retry_count >= 10) {
-                    CFW_LOG_ERROR("[SceneSystem] Actor 0x%lx unload failed after 10 retries, resource is permanently in use",
+                    CFW_LOG_ERROR("[SceneSystem] Actor 0x%lx unload failed after 10 retries, resource is permanently in use — reverting to Loaded",
                                  (unsigned long)task.actor);
                     scene_state.unload_retry_counts.erase(task.actor);
-                    // 不强制设为Loaded，保留Unloading状态，由业务层处理
-                    // 同时不发布任何事件，避免状态混乱
+                    scene_state.actor_load_states[task.actor] = ActorLoadState::Loaded;
                 } else {
                     auto actor_read = actor_storage.try_acquire_read(task.actor);
                     if (actor_read.valid()) {
@@ -1199,7 +1220,11 @@ void GeometrySystem::on_unload_requested(const Events::ActorUnloadRequestedEvent
             scene_state.actor_load_states[e.actor] = ActorLoadState::Loaded;
             CFW_LOG_NOTICE("[GeometrySystem] Cancelled pending unload for actor {}", e.actor);
         }
-
+        if (scene_state.loading_tasks.count(e.actor)) {
+            // 加载进行中 — 将状态设为 Unloaded，加载完成时 process_async_tasks 检测到非 Loading 状态会跳过
+            scene_state.actor_load_states[e.actor] = ActorLoadState::Unloaded;
+            CFW_LOG_NOTICE("[GeometrySystem] Unload requested during load for actor {} — cancelling load", e.actor);
+        }
         return;
     }
 
@@ -1231,10 +1256,12 @@ void GeometrySystem::on_unload_requested(const Events::ActorUnloadRequestedEvent
 // ============================================================================
 
 void GeometrySystem::set_simplification_config(const MeshSimplificationConfig& cfg) {
+    std::unique_lock lock(impl_->mtx);
     impl_->simplification_cfg = cfg;
 }
 
 const MeshSimplificationConfig& GeometrySystem::get_simplification_config() const {
+    std::shared_lock lock(impl_->mtx);
     return impl_->simplification_cfg;
 }
 
@@ -1336,7 +1363,15 @@ const LODMeshBuffers* GeometrySystem::resolve_lod_buffers(
 // ============================================================================
 
 void GeometrySystem::upload_lod_from_scene_data() {
-    if (!impl_->simplification_cfg.auto_on_load) return;
+    // 快照 simplification_cfg，与 set_simplification_config 同步
+    bool auto_on_load;
+    int max_lod_levels;
+    {
+        std::shared_lock lock(impl_->mtx);
+        auto_on_load = impl_->simplification_cfg.auto_on_load;
+        max_lod_levels = impl_->simplification_cfg.max_lod_levels;
+    }
+    if (!auto_on_load) return;
 
     auto& resource_manager = Resource::ResourceManager::get_instance();
     auto& hub = SharedDataHub::instance();
@@ -1357,12 +1392,12 @@ void GeometrySystem::upload_lod_from_scene_data() {
         for (uint32_t mesh_idx = 0; mesh_idx < static_cast<uint32_t>(geom_dev.mesh_handles.size()); ++mesh_idx) {
             uint64_t lod_key = Impl::make_lod_key(geom_handle, mesh_idx);
 
-            // 已有缓存且模型未变更则跳过（model_resource_handle 比较防止 slot 复用）
+            // 已有缓存且模型未变更则跳过（model_id 比较防止 slot 复用）
             {
                 std::shared_lock lock(impl_->lod_cache_mutex);
                 auto cache_it = impl_->lod_cache.find(lod_key);
                 if (cache_it != impl_->lod_cache.end()
-                    && cache_it->second.model_resource_handle == geom_dev.model_resource_handle)
+                    && cache_it->second.model_id == model_id)
                     continue;
             }
 
@@ -1378,7 +1413,7 @@ void GeometrySystem::upload_lod_from_scene_data() {
 
             // 创建缓存条目
             Impl::LODCacheEntry entry;
-            entry.model_resource_handle = geom_dev.model_resource_handle;
+            entry.model_id = model_id;
             auto& mesh_dev = geom_dev.mesh_handles[mesh_idx];
 
             // LOD 0：复用现有的 GPU 缓冲
@@ -1393,7 +1428,7 @@ void GeometrySystem::upload_lod_from_scene_data() {
             entry.levels.push_back(std::move(lod0));
 
             // LOD 1..N：从导入时 meshoptimizer 生成的数据创建 GPU 缓冲
-            for (size_t lod_idx = 0; lod_idx < mesh.lod_levels.size() && lod_idx < static_cast<size_t>(impl_->simplification_cfg.max_lod_levels - 1); ++lod_idx) {
+            for (size_t lod_idx = 0; lod_idx < mesh.lod_levels.size() && lod_idx < static_cast<size_t>(max_lod_levels - 1); ++lod_idx) {
                 auto& lod_data = mesh.lod_levels[lod_idx];
                 if (lod_data.vertices.empty() || lod_data.indices.empty()) continue;
 

--- a/src/systems/geometry/geometry_system.cpp
+++ b/src/systems/geometry/geometry_system.cpp
@@ -1046,6 +1046,11 @@ void GeometrySystem::process_async_tasks() {
 
     for (const auto& task : completed_loads) {
         if (task.rid != Resource::IResource::INVALID_UID) {
+            // 重建 GPU 资源（mesh_handles + 纹理），恢复 model_resource_handle
+            // 必须在发布 ActorLoadCompletedEvent 之前完成，
+            // 以保证事件订阅者（渲染线程等）能读到有效的 GPU 缓冲
+            rebuild_actor_gpu_resources(task.actor, task.rid);
+
             impl_->ctx->event_bus()->publish(Events::ActorLoadCompletedEvent{task.scene_handle,task.actor});
             CFW_LOG_DEBUG("[SceneSystem] Actor {} loaded (resource: {})", task.actor, task.rid);
         }else {
@@ -1065,6 +1070,9 @@ void GeometrySystem::process_async_tasks() {
     std::vector<CompletedUnloadTask> failed_unloads;
     for (const auto& task : completed_unloads) {
         if (task.success) {
+            // 释放 actor 关联的 GPU 资源（HardwareBuffer / HardwareImage）
+            release_actor_gpu_resources(task.actor);
+
             {
                 std::unique_lock lock(impl_->mtx);
                 auto scene_it = impl_->scenes.find(task.scene_handle);
@@ -1331,12 +1339,20 @@ void GeometrySystem::upload_lod_from_scene_data() {
     if (!impl_->simplification_cfg.auto_on_load) return;
 
     auto& resource_manager = Resource::ResourceManager::get_instance();
-    auto& geom_storage = SharedDataHub::instance().geometry_storage();
+    auto& hub = SharedDataHub::instance();
+    auto& geom_storage = hub.geometry_storage();
 
     for (auto it = geom_storage.cbegin(); it != geom_storage.cend(); ++it) {
         const GeometryDevice& geom_dev = *it;
         auto geom_handle = reinterpret_cast<std::uintptr_t>(&geom_dev);
         if (!geom_dev.model_resource_handle) continue;
+
+        // 通过 ModelResource 解析真正的 ResourceManager UID
+        std::uint64_t model_id = 0;
+        if (auto model_res = hub.model_resource_storage().try_acquire_read(geom_dev.model_resource_handle)) {
+            model_id = model_res->model_id;
+        }
+        if (model_id == 0) continue;
 
         for (uint32_t mesh_idx = 0; mesh_idx < static_cast<uint32_t>(geom_dev.mesh_handles.size()); ++mesh_idx) {
             uint64_t lod_key = Impl::make_lod_key(geom_handle, mesh_idx);
@@ -1351,7 +1367,7 @@ void GeometrySystem::upload_lod_from_scene_data() {
             }
 
             // 从 ResourceManager 读取 Scene 数据
-            auto scene_read = resource_manager.acquire_read<Resource::Scene>(geom_dev.model_resource_handle);
+            auto scene_read = resource_manager.acquire_read<Resource::Scene>(model_id);
             if (!scene_read.valid()) continue;
 
             auto& scene = *scene_read;

--- a/src/systems/geometry/geometry_system.cpp
+++ b/src/systems/geometry/geometry_system.cpp
@@ -516,6 +516,469 @@ void GeometrySystem::on_unload_completed(const Events::ActorUnloadCompletedEvent
 }
 
 // ============================================================================
+// GPU 资源释放（unload 时由 process_async_tasks 调用）
+// ============================================================================
+
+// ============================================================================
+// release_actor_gpu_resources
+// 功能：释放指定 actor 占用的全部 GPU 资源（显存中的顶点/索引缓冲和纹理）
+// 调用时机：process_async_tasks() 中处理 ActorUnloadCompletedEvent 时
+// 注意：只清理 GPU 端资源，不删除 SharedDataHub 中的存储槽位
+// ============================================================================
+void GeometrySystem::release_actor_gpu_resources(std::uintptr_t actor) {
+    // ---- 第 0 步：获取全局数据中心单例 ----
+    // SharedDataHub 是所有系统共享的数据仓库，存 Actor/Profile/Geometry 等设备数据
+    auto& hub = SharedDataHub::instance();
+
+    // ---- 第 1 步：以只读模式获取 actor 数据 ----
+    // try_acquire_read 返回一个 RAII 读锁守卫，离开作用域自动释放
+    auto actor_read = hub.actor_storage().try_acquire_read(actor);
+    if (!actor_read.valid()) return;  // actor 句柄无效（可能已被销毁），直接返回
+
+    // ---- 第 2 步：用 visited 集合去重 ----
+    // 一个 actor 的多个 profile 可能共享同一个 geometry（例如 optics 和 mechanics 引用同一几何体）
+    // 用 unordered_set 记录已处理的 geometry，避免重复释放
+    std::unordered_set<std::uintptr_t> visited_geometry_handles;
+
+    // ---- 第 3 步：遍历 actor 身上每个 Profile ----
+    // Profile 是"配件槽位"——它聚合了 optics/mechanics/geometry/acoustics 的句柄
+    for (auto profile_handle : actor_read->profile_handles) {
+        auto profile = hub.profile_storage().try_acquire_read(profile_handle);
+        if (!profile) continue;  // profile 句柄已失效
+
+        // ---- 第 4 步：从 Profile 的 4 条路径收集 geometry 句柄 ----
+        // 路径 A：Profile 自身直接挂载的 geometry_handle
+        // 路径 B：Profile → OpticsDevice → geometry_handle（光学设备可能引用几何体）
+        // 路径 C：Profile → MechanicsDevice → geometry_handle（力学设备必然引用几何体，最常用）
+        // 路径 D：Profile → AcousticsDevice → geometry_handle（声学设备可能引用几何体）
+        std::vector<std::uintptr_t> geom_handles;
+
+        // 路径 A：Profile 自身的 geometry 直连
+        if (profile->geometry_handle != 0) {
+            geom_handles.push_back(profile->geometry_handle);
+        }
+        // 路径 B：OpticsDevice（视觉渲染设备）→ geometry
+        if (profile->optics_handle != 0) {
+            if (auto optics = hub.optics_storage().try_acquire_read(profile->optics_handle)) {
+                if (optics->geometry_handle != 0) {
+                    geom_handles.push_back(optics->geometry_handle);
+                }
+            }
+        }
+        // 路径 C：MechanicsDevice（物理/变换设备）→ geometry（最常用的路径）
+        if (profile->mechanics_handle != 0) {
+            if (auto mech = hub.mechanics_storage().try_acquire_read(profile->mechanics_handle)) {
+                if (mech->geometry_handle != 0) {
+                    geom_handles.push_back(mech->geometry_handle);
+                }
+            }
+        }
+        // 路径 D：AcousticsDevice（声学设备）→ geometry
+        if (profile->acoustics_handle != 0) {
+            if (auto acoustics = hub.acoustics_storage().try_acquire_read(profile->acoustics_handle)) {
+                if (acoustics->geometry_handle != 0) {
+                    geom_handles.push_back(acoustics->geometry_handle);
+                }
+            }
+        }
+
+        // ---- 第 5 步：对每个收集到的 geometry 释放 GPU 资源 ----
+        for (auto geom_handle : geom_handles) {
+            // visited_geometry_handles.insert() 返回 pair<iter, bool>
+            // .second == false 表示已存在 → 跳过，避免重复处理
+            if (!visited_geometry_handles.insert(geom_handle).second) continue;
+
+            // ---- 第 5.1 步：统计该 geometry 有多少个 mesh（子网格）----
+            // 一个 GeometryDevice 可能包含多个 MeshDevice（例如一个模型有多个材质）
+            uint32_t mesh_count = 0;
+            if (auto geom_read = hub.geometry_storage().try_acquire_read(geom_handle)) {
+                mesh_count = static_cast<uint32_t>(geom_read->mesh_handles.size());
+            } else {
+                continue;  // geometry 句柄已失效
+            }
+
+            // ---- 第 5.2 步：清理 LOD 缓存 ----
+            // 每个 mesh 可能在 upload_lod_from_scene_data() 中创建了多级 LOD GPU 缓冲
+            // make_lod_key(geom_handle, i) 生成唯一键：(geometry_handle << 32) | mesh_index
+            {
+                std::unique_lock lod_lock(impl_->lod_cache_mutex);  // 独占锁（写操作）
+                for (uint32_t i = 0; i < mesh_count; ++i) {
+                    impl_->lod_cache.erase(Impl::make_lod_key(geom_handle, i));
+                }
+            }  // lod_lock 在此析构，自动释放互斥锁
+
+            // ---- 第 5.3 步：销毁 mesh_handles 中的 GPU 缓冲 ----
+            // mesh_handles 是 vector<MeshDevice>，每个 MeshDevice 内含：
+            //   vertexBuffer / indexBuffer（渲染用）
+            //   vertexStorageBuffer / indexStorageBuffer（Compute Shader 用）
+            //   textureBuffer（纹理）
+            // clear() 触发每个元素的析构 → HardwareBuffer/HardwareImage 析构 → GPU 显存归还
+            // 注意：model_resource_handle 保留不删，以便 reload 时能找到模型资源条目
+            if (auto geom_write = hub.geometry_storage().try_acquire_write(geom_handle)) {
+                geom_write->mesh_handles.clear();
+            }  // geom_write 析构时自动释放写锁
+
+            // ---- 第 5.4 步：日志 ----
+            CFW_LOG_NOTICE("[GeometrySystem] Released GPU resources for geometry {}, "
+                           "{} mesh(es), actor {}",
+                           geom_handle,   // geometry 在 SharedDataHub 中的句柄地址
+                           mesh_count,    // 释放了多少个 mesh 的 GPU 缓冲
+                           actor);        // 所属 actor 句柄
+        }
+    }
+}
+
+// ============================================================================
+// rebuild_actor_gpu_resources
+// 功能：释放后重新加载 actor 时，重建全部 GPU 资源（顶点/索引缓冲 + 纹理）
+// 调用时机：process_async_tasks() 检测到 load 任务完成后，发布事件前
+// 参数：
+//   actor — actor 句柄（SharedDataHub 中的地址）
+//   rid   — 资源 UID（ResourceManager 分配的唯一标识，由 import_async 返回）
+// 说明：这个函数是 unload → reload 生命周期中"重建"环节的核心
+// ============================================================================
+void GeometrySystem::rebuild_actor_gpu_resources(std::uintptr_t actor, std::uint64_t rid) {
+    // ---- 第 0 步：获取两个全局单例 ----
+    // SharedDataHub：管理所有系统共享的设备数据（actor/profile/geometry 等）
+    auto& hub = SharedDataHub::instance();
+    // ResourceManager：管理所有资源文件（Scene/Image 等），通过 UID 查找
+    auto& resource_manager = Resource::ResourceManager::get_instance();
+
+    // ---- 第 1 步：读取 actor 数据 ----
+    auto actor_read = hub.actor_storage().try_acquire_read(actor);
+    if (!actor_read.valid()) return;  // actor 句柄无效
+
+    // ---- 第 2 步：去重集合（与 release 函数逻辑相同）----
+    // 多个 profile 可能引用同一 geometry，用 set 防止重复重建
+    std::unordered_set<std::uintptr_t> visited_geometry_handles;
+
+    // ---- 第 3 步：遍历 actor 的所有 profile ----
+    for (auto profile_handle : actor_read->profile_handles) {
+        auto profile = hub.profile_storage().try_acquire_read(profile_handle);
+        if (!profile) continue;
+
+        // ---- 第 4 步：4 条路径收集 geometry 句柄（同 release 逻辑）----
+        // 路径 A：Profile 直连 geometry
+        // 路径 B：Profile → OpticsDevice → geometry
+        // 路径 C：Profile → MechanicsDevice → geometry（最常用）
+        // 路径 D：Profile → AcousticsDevice → geometry
+        std::vector<std::uintptr_t> geom_handles;
+
+        // 路径 A：profile 自身的 geometry_handle
+        if (profile->geometry_handle != 0) {
+            geom_handles.push_back(profile->geometry_handle);
+        }
+        // 路径 B：光学设备 → geometry
+        if (profile->optics_handle != 0) {
+            if (auto optics = hub.optics_storage().try_acquire_read(profile->optics_handle)) {
+                if (optics->geometry_handle != 0) {
+                    geom_handles.push_back(optics->geometry_handle);
+                }
+            }
+        }
+        // 路径 C：力学/物理设备 → geometry（渲染对象的主要路径）
+        if (profile->mechanics_handle != 0) {
+            if (auto mech = hub.mechanics_storage().try_acquire_read(profile->mechanics_handle)) {
+                if (mech->geometry_handle != 0) {
+                    geom_handles.push_back(mech->geometry_handle);
+                }
+            }
+        }
+        // 路径 D：声学设备 → geometry
+        if (profile->acoustics_handle != 0) {
+            if (auto acoustics = hub.acoustics_storage().try_acquire_read(profile->acoustics_handle)) {
+                if (acoustics->geometry_handle != 0) {
+                    geom_handles.push_back(acoustics->geometry_handle);
+                }
+            }
+        }
+
+        // ---- 第 5 步：对每个 geometry 重建 GPU 资源 ----
+        for (auto geom_handle : geom_handles) {
+            // 去重：同一 geometry 只处理一次
+            if (!visited_geometry_handles.insert(geom_handle).second) continue;
+
+            // ---- 第 5.1 步：判断是否需要重建 ----
+            // model_resource_handle 是 SharedDataHub 中 ModelResource 条目的句柄
+            // release() 时保留了它（未置零），通过它找到对应的模型资源条目
+            // mesh_handles 在 release() 时已 clear()，所以 empty() == true 表示需要重建
+            // 初始加载时 Python API 已填充 mesh_handles，此时不为空 → 无需重建
+            std::uintptr_t model_res_handle = 0;  // ModelResource 句柄
+            bool needs_rebuild = false;            // 是否需要重建 GPU 缓冲
+            {
+                auto geom_read = hub.geometry_storage().try_acquire_read(geom_handle);
+                if (!geom_read) continue;  // geometry 已失效
+                model_res_handle = geom_read->model_resource_handle;
+                // 关键判断：mesh_handles 为空 → 被 release() 清理过 → 需要重建
+                //          mesh_handles 不为空 → 初始加载已完成 → 无需重建
+                needs_rebuild = geom_read->mesh_handles.empty();
+            }  // geom_read 析构，释放读锁
+
+            // ---- 第 5.2 步：更新 ModelResource 中的 model_id ----
+            // reload 时 import_async 可能分配新的资源 UID，必须更新
+            // 无论是否需要 rebuild 都要更新，确保后续 LOD 上传能正确查找到 Scene 数据
+            if (model_res_handle != 0) {
+                if (auto model_res = hub.model_resource_storage().try_acquire_write(model_res_handle)) {
+                    model_res->model_id = rid;  // 写入新的资源 UID
+                }
+            }
+
+            // ---- 第 5.3 步：如果不需要重建，跳过此 geometry ----
+            // 初始加载场景：mesh_handles 已在 Python API 层创建完毕
+            if (!needs_rebuild) {
+                continue;  // 无需重建，直接处理下一个 geometry
+            }
+
+            // ---- 第 5.4 步：从 ResourceManager 获取导入的 Scene 数据 ----
+            // rid 是 import_async 完成后返回的资源唯一标识
+            // Scene 资源包含完整的模型数据：顶点/索引/材质/纹理/LOD 等
+            auto scene_read = resource_manager.acquire_read<Resource::Scene>(rid);
+            if (!scene_read.valid()) {
+                CFW_LOG_ERROR("[GeometrySystem] Failed to acquire Scene resource for rid={}", rid);
+                continue;  // 资源无效，跳过
+            }
+            auto& scene = *scene_read;  // 解引用读锁守卫，获得 Scene 数据引用
+
+            // ================================================================
+            // 阶段 A：创建 MeshDevice 数组
+            // 为 Scene 中的每个 mesh 创建 GPU 缓冲（顶点/索引/纹理）
+            // 分两步：先创建所有 HardwareBuffer/HardwareImage，再批量上传纹理数据
+            // ================================================================
+            std::vector<MeshDevice> mesh_devices;                     // 输出：新的 mesh 设备数组
+            mesh_devices.reserve(scene.data.meshes.size());            // 预分配内存，避免 realloc
+
+            // ---- 待上传纹理列表（第一阶段收集，第二阶段批量执行）----
+            // 纹理上传涉及 GPU 传输，批量处理比逐个处理效率高
+            struct PendingTextureUpload {
+                std::uint32_t mesh_idx;               // 对应 mesh_devices 中的索引
+                HardwareImage* texture;               // 指向已创建的 HardwareImage 对象
+                std::vector<unsigned char> rgba_data; // 纹理像素数据（RGBA 格式）
+                unsigned char* data_ptr;              // 指向 rgba_data 中数据的指针
+            };
+            std::vector<PendingTextureUpload> pending_uploads;
+            pending_uploads.reserve(scene.data.meshes.size());
+
+            // ---- 创建共享的 1x1 白色占位纹理 ----
+            // 用于无纹理的 mesh，确保渲染管线始终有纹理可采样
+            // static → 全局唯一，所有无纹理 mesh 共享同一张（节省显存）
+            // lambda 立即执行 → 程序启动时构造一次
+            static HardwareImage shared_placeholder_texture = []() {
+                // 构造 1×1 像素、RGBA8 sRGB 格式的纹理创建信息
+                HardwareImageCreateInfo placeholder_info{};
+                placeholder_info.width        = 1;                       // 1 像素宽
+                placeholder_info.height       = 1;                       // 1 像素高
+                placeholder_info.format       = ImageFormat::RGBA8_SRGB; // sRGB 色彩空间
+                placeholder_info.usage        = ImageUsage::SampledImage; // 可作为着色器采样源
+                placeholder_info.arrayLayers  = 1;                       // 无数组层
+                placeholder_info.mipLevels    = 1;                       // 无 mipmap
+
+                static const unsigned char white_pixel[4] = {255, 255, 255, 255};  // 不透明白色
+                HardwareImage texture(placeholder_info);               // 创建 GPU 纹理对象
+                HardwareExecutor temp_executor;                        // 临时命令执行器
+                // 将白色像素数据拷贝到 GPU 纹理，提交执行
+                temp_executor << texture.copyFrom(white_pixel) << temp_executor.commit();
+                return texture;  // 返回创建好的纹理（move 语义）
+            }();
+
+            // ---- 第一阶段：遍历所有 mesh，创建 GPU 缓冲 ----
+            for (std::uint32_t mesh_idx = 0; mesh_idx < scene.data.meshes.size(); ++mesh_idx) {
+                const auto& mesh = scene.data.meshes[mesh_idx];  // 当前 mesh 的 CPU 端数据
+                MeshDevice dev{};  // 零初始化 MeshDevice（所有句柄为 0/null）
+
+                // ---- 创建顶点/索引缓冲（4 个）----
+                // vertexBuffer / indexBuffer：渲染管线使用（Vertex Shader 读取）
+                // vertexStorageBuffer / indexStorageBuffer：Compute Shader 使用（可读写）
+                // get_mesh_vertices() 返回 meshopt 优化后的顶点数组
+                // get_mesh_indices() 返回 meshopt 优化后的索引数组
+                dev.vertexBuffer        = HardwareBuffer(scene.get_mesh_vertices(mesh_idx), BufferUsage::VertexBuffer);
+                dev.indexBuffer         = HardwareBuffer(scene.get_mesh_indices(mesh_idx),  BufferUsage::IndexBuffer);
+                dev.vertexStorageBuffer = HardwareBuffer(scene.get_mesh_vertices(mesh_idx), BufferUsage::StorageBuffer);
+                dev.indexStorageBuffer  = HardwareBuffer(scene.get_mesh_indices(mesh_idx),  BufferUsage::StorageBuffer);
+
+                // ---- 材质索引 ----
+                // material_index 指向 scene.data.materials 数组
+                // InvalidIndex（最大值）表示无材质 → 降级为 0（使用默认材质）
+                dev.materialIndex = (mesh.material_index != Resource::InvalidIndex)
+                                        ? mesh.material_index                    // 有效材质索引
+                                        : 0;                                    // 降级为默认材质
+
+                // ---- 读取材质颜色（base_color：RGBA 漫反射颜色）----
+                if (mesh.material_index != Resource::InvalidIndex &&
+                    mesh.material_index < scene.data.materials.size()) {
+                    dev.materialColor = scene.data.materials[mesh.material_index].base_color;
+                }
+
+                // ---- 纹理处理 ----
+                bool texture_created = false;               // 标记：是否已创建纹理
+                HardwareImageCreateInfo create_info{};       // 纹理创建参数（零初始化）
+
+                // 检查是否有有效材质和纹理
+                if (mesh.material_index != Resource::InvalidIndex &&
+                    mesh.material_index < scene.data.materials.size()) {
+                    // 从材质中获取 albedo（漫反射）纹理 ID
+                    auto texture_id = scene.data.materials[mesh.material_index].albedo_texture;
+
+                    if (texture_id != Resource::InvalidTextureId) {
+                        // 尝试从资源管理器获取纹理图像数据
+                        auto texture_data = resource_manager.acquire_read<Resource::Image>(texture_id);
+                        if (texture_data && texture_data->get_data() != nullptr) {
+                            const int tex_width    = texture_data->get_width();     // 纹理宽度（像素）
+                            const int tex_height   = texture_data->get_height();    // 纹理高度（像素）
+                            const int tex_channels = texture_data->get_channels();  // 颜色通道数（1/3/4）
+
+                            if (tex_width > 0 && tex_height > 0 && tex_channels > 0) {
+                                // ========================================
+                                // 分支 A：压缩纹理（BC1/BC3/ASTC）
+                                // ========================================
+                                if (texture_data->is_compressed()) {
+                                    // 获取压缩后的数据（GPU 可直接使用的格式）
+                                    const auto& compressed = texture_data->get_compressed_data();
+                                    create_info.width        = tex_width;
+                                    create_info.height       = tex_height;
+                                    create_info.usage        = ImageUsage::SampledImage;
+                                    create_info.arrayLayers  = 1;
+                                    create_info.mipLevels    = 1;
+
+                                    // 根据压缩格式设置对应的 GPU 图像格式
+                                    if (compressed.format == Resource::CompressedData::Format::BC1) {
+                                        create_info.format = ImageFormat::BC1_RGB_SRGB;     // DXT1，无 alpha
+                                    } else if (compressed.format == Resource::CompressedData::Format::BC3) {
+                                        create_info.format = ImageFormat::BC3_RGBA_SRGB;    // DXT5，含 alpha
+                                    } else if (compressed.format == Resource::CompressedData::Format::ASTC_4x4) {
+                                        create_info.format = ImageFormat::ASTC_4x4_SRGB;    // 移动端常用
+                                    }
+
+                                    // 将压缩数据加入待上传队列
+                                    PendingTextureUpload upload{mesh_idx, nullptr, {}, nullptr};
+                                    upload.rgba_data.assign(compressed.data.begin(), compressed.data.end());
+                                    upload.data_ptr = upload.rgba_data.data();
+
+                                    // 创建 GPU 纹理对象（此时尚未上传像素数据）
+                                    dev.textureBuffer = HardwareImage(create_info);
+                                    upload.texture = &dev.textureBuffer;
+                                    pending_uploads.push_back(std::move(upload));
+                                    texture_created = true;
+                                }
+                                // ========================================
+                                // 分支 B：未压缩纹理（RGBA 像素数据）
+                                // ========================================
+                                else {
+                                    create_info.width        = tex_width;
+                                    create_info.height       = tex_height;
+                                    create_info.format       = ImageFormat::RGBA8_SRGB;   // 统一转为 RGBA8
+                                    create_info.usage        = ImageUsage::SampledImage;
+                                    create_info.arrayLayers  = 1;
+                                    create_info.mipLevels    = 1;
+
+                                    unsigned char* src_data = texture_data->get_data();  // 原始像素数据指针
+                                    PendingTextureUpload upload{mesh_idx, nullptr, {}, nullptr};
+
+                                    // ---- 根据通道数转换为 RGBA ----
+                                    if (tex_channels == 4) {
+                                        // RGBA：直接拷贝，无需转换
+                                        upload.rgba_data.assign(src_data,
+                                            src_data + static_cast<size_t>(tex_width) * tex_height * 4);
+                                        upload.data_ptr = upload.rgba_data.data();
+                                    } else if (tex_channels == 3) {
+                                        // RGB → RGBA：补充 alpha=255（完全不透明）
+                                        upload.rgba_data.resize(static_cast<size_t>(tex_width) * tex_height * 4);
+                                        for (int i = 0; i < tex_width * tex_height; ++i) {
+                                            upload.rgba_data[i * 4 + 0] = src_data[i * 3 + 0];  // R
+                                            upload.rgba_data[i * 4 + 1] = src_data[i * 3 + 1];  // G
+                                            upload.rgba_data[i * 4 + 2] = src_data[i * 3 + 2];  // B
+                                            upload.rgba_data[i * 4 + 3] = 255;                  // A=不透明
+                                        }
+                                        upload.data_ptr = upload.rgba_data.data();
+                                    } else if (tex_channels == 1) {
+                                        // 灰度 → RGBA：R=G=B=灰度值, A=255
+                                        upload.rgba_data.resize(static_cast<size_t>(tex_width) * tex_height * 4);
+                                        for (int i = 0; i < tex_width * tex_height; ++i) {
+                                            upload.rgba_data[i * 4 + 0] = src_data[i];  // R=灰度
+                                            upload.rgba_data[i * 4 + 1] = src_data[i];  // G=灰度
+                                            upload.rgba_data[i * 4 + 2] = src_data[i];  // B=灰度
+                                            upload.rgba_data[i * 4 + 3] = 255;          // A=不透明
+                                        }
+                                        upload.data_ptr = upload.rgba_data.data();
+                                    }
+
+                                    // 如果有有效数据，创建 GPU 纹理并加入上传队列
+                                    if (upload.data_ptr != nullptr) {
+                                        dev.textureBuffer = HardwareImage(create_info);   // 创建 GPU 纹理对象
+                                        upload.texture = &dev.textureBuffer;              // 指向刚创建的纹理
+                                        pending_uploads.push_back(std::move(upload));    // 入队等待批量上传
+                                        texture_created = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // ---- 无纹理的兜底：使用共享白色占位纹理 ----
+                // 确保每个 mesh 都有纹理句柄，避免渲染时空指针
+                if (!texture_created) {
+                    dev.textureBuffer = shared_placeholder_texture;  // 拷贝共享纹理句柄
+                }
+
+                // ---- 将构建好的 MeshDevice 加入数组 ----
+                mesh_devices.emplace_back(std::move(dev));
+            }  // 第一阶段结束：所有 mesh 的 GPU 缓冲已创建，纹理像素尚未上传
+
+            // ================================================================
+            // 阶段 B：批量上传纹理像素到 GPU
+            // 使用 HardwareExecutor 执行异步 GPU 传输
+            // 每 32 个纹理一批，平衡内存占用和批次开销
+            // ================================================================
+            if (!pending_uploads.empty()) {
+                constexpr size_t kBatchSize = 32;  // 每批最多 32 个纹理
+                for (size_t batch_start = 0; batch_start < pending_uploads.size(); batch_start += kBatchSize) {
+                    size_t batch_end = std::min(batch_start + kBatchSize, pending_uploads.size());
+
+                    HardwareExecutor batch_executor;  // GPU 命令执行器
+                    // 将本批次所有纹理的 copyFrom 命令加入执行器
+                    for (size_t i = batch_start; i < batch_end; ++i) {
+                        auto& upload = pending_uploads[i];
+                        HardwareImage& tex = mesh_devices[upload.mesh_idx].textureBuffer;
+                        batch_executor << tex.copyFrom(upload.data_ptr);  // 将像素数据拷贝到 GPU
+                    }
+                    // 提交所有命令到 GPU 队列并执行
+                    batch_executor << batch_executor.commit();
+                    batch_executor.waitForDeferredResources();  // 等待本批次传输完成
+                }
+            }
+
+            // ================================================================
+            // 阶段 C：写回 GeometryDevice
+            // 将重建好的 mesh_handles 写回 SharedDataHub
+            // ================================================================
+
+            // ---- 先清理旧 LOD 缓存 ----
+            // mesh_handles 已经重建（新的 GPU 缓冲句柄），旧 LOD 条目指向已销毁的缓冲
+            // 必须清除，否则下一帧 upload_lod_from_scene_data() 会检测到 mismatched handles 并重建
+            {
+                std::unique_lock lod_lock(impl_->lod_cache_mutex);  // 独占锁
+                for (uint32_t i = 0; i < static_cast<uint32_t>(mesh_devices.size()); ++i) {
+                    impl_->lod_cache.erase(Impl::make_lod_key(geom_handle, i));
+                }
+            }  // lod_lock 析构
+
+            // ---- 将新 mesh_handles 写入 GeometryDevice ----
+            if (auto geom_write = hub.geometry_storage().try_acquire_write(geom_handle)) {
+                geom_write->mesh_handles = std::move(mesh_devices);  // move 语义，避免拷贝
+            }  // geom_write 析构，释放写锁
+
+            // ---- 日志：记录重建完成 ----
+            CFW_LOG_NOTICE("[GeometrySystem] Rebuilt GPU resources for geometry {}, "
+                           "{} mesh(es), actor {}, rid={}",
+                           geom_handle,                // geometry 句柄
+                           scene.data.meshes.size(),   // 重建的 mesh 数量
+                           actor,                      // 所属 actor
+                           rid);                       // 资源 UID
+        }
+    }
+}
+
+// ============================================================================
 // 异步资源任务处理
 // ============================================================================
 

--- a/src/systems/optics/optics_system.cpp
+++ b/src/systems/optics/optics_system.cpp
@@ -1,11 +1,13 @@
 #include <corona/events/display_system_events.h>
 #include <corona/events/optics_system_events.h>
 #include <corona/kernel/core/i_logger.h>
+#include <corona/kernel/core/kernel_context.h>
 #include <corona/kernel/event/i_event_bus.h>
 #include <corona/kernel/event/i_event_stream.h>
 #include <corona/resource/resource_manager.h>
 #include <corona/resource/types/image.h>
 #include <corona/shared_data_hub.h>
+#include <corona/systems/geometry/geometry_system.h>
 #include <corona/systems/optics/optics_system.h>
 
 #include <algorithm>
@@ -430,6 +432,17 @@ bool OpticsSystem::initialize(Kernel::ISystemContext* ctx) {
 void OpticsSystem::update() {
     apply_pending_camera_moves();
 
+    // 延迟获取 GeometrySystem 指针（不能在 initialize() 中获取，会死锁）
+    // initialize_all() 持锁遍历系统，get_system() 也需同锁 → 非递归 mutex 重入崩溃
+    if (!geometry_system_ && !geometry_system_queried_) {
+        geometry_system_queried_ = true;
+        auto& kernel = Kernel::KernelContext::instance();
+        if (auto* sys_mgr = kernel.system_manager()) {
+            auto sys = sys_mgr->get_system("Geometry");
+            geometry_system_ = dynamic_cast<GeometrySystem*>(sys ? sys.get() : nullptr);
+        }
+    }
+
     // Check for pending backend switch request before executing either render path.
     int pending = pending_backend_.load(std::memory_order_relaxed);
     RenderBackend requested = static_cast<RenderBackend>(pending);
@@ -589,14 +602,56 @@ void OpticsSystem::optics_pipeline(float frame_count, uint64_t frame_index) {
                             // 版 try_acquire_write 等锁（不漏帧），槽位失效时返回无效句柄而非抛异常。
                             if (auto geom = geom_storage.try_acquire_write(optics.geometry_handle)) {
                                 ktm::fmat4x4 model_matrix{ktm::fmat4x4::from_eye()};
+                                ktm::fvec3 world_center{0.0f, 0.0f, 0.0f};
                                 if (auto transform = transform_storage.try_acquire_read(geom->transform_handle)) {
                                     model_matrix = transform->compute_matrix();
+                                    // 必须在 camera_basis 变换前提取世界位置（否则 model_matrix[3] 不再是世界坐标）
+                                    world_center = transform->position;
                                     if (camera_basis != nullptr) {
                                         model_matrix = multiply_ktm_mat4(*camera_basis, model_matrix);
                                     }
                                 }
 
-                                for (auto& m : geom->mesh_handles) {
+                                // ---- 计算物体在世界空间中的包围信息（用于LOD选择） ----
+                                float bounding_radius = 1.0f;
+                                bool use_lod = false;
+
+                                if (geometry_system_) {
+                                    auto& ms = SharedDataHub::instance().mechanics_storage();
+                                    if (auto mech = ms.try_acquire_read(profile->mechanics_handle)) {
+                                        float dx = mech->max_xyz.x - mech->min_xyz.x;
+                                        float dy = mech->max_xyz.y - mech->min_xyz.y;
+                                        float dz = mech->max_xyz.z - mech->min_xyz.z;
+                                        bounding_radius = std::sqrt(dx*dx + dy*dy + dz*dz) * 0.5f;
+                                        use_lod = true;
+                                    }
+                                }
+
+                                for (uint32_t mesh_index = 0; mesh_index < static_cast<uint32_t>(geom->mesh_handles.size()); ++mesh_index) {
+                                    auto& m = geom->mesh_handles[mesh_index];
+
+                                    // ---- LOD 缓冲替换 ----
+                                    HardwareBuffer render_vb = m.vertexBuffer;
+                                    HardwareBuffer render_ib = m.indexBuffer;
+                                    HardwareBuffer render_vs = m.vertexStorageBuffer;
+                                    HardwareBuffer render_is = m.indexStorageBuffer;
+
+                                    if (use_lod && geometry_system_) {
+                                        float screen_ratio = GeometrySystem::compute_screen_ratio(
+                                            camera->position, camera->fov,
+                                            world_center, bounding_radius);
+
+                                        if (auto* lod_buf = geometry_system_->resolve_lod_buffers(
+                                                optics.geometry_handle, mesh_index,
+                                                screen_ratio)) {
+                                            if (lod_buf->vertex_buffer && lod_buf->index_buffer) {
+                                                render_vb = lod_buf->vertex_buffer;
+                                                render_ib = lod_buf->index_buffer;
+                                                if (lod_buf->vertex_storage) render_vs = lod_buf->vertex_storage;
+                                                if (lod_buf->index_storage)  render_is = lod_buf->index_storage;
+                                            }
+                                        }
+                                    }
                                     // --- Collect material info ---
                                     auto materialID = static_cast<uint32_t>(batch.materials.size());
                                     {
@@ -647,11 +702,11 @@ void OpticsSystem::optics_pipeline(float frame_count, uint64_t frame_index) {
                                     {
                                         Hardware::InstanceInfo inst{};
                                         inst.modelMatrix = model_matrix;
-                                        inst.vertexBufferIndex = m.vertexStorageBuffer
-                                                                     ? m.vertexStorageBuffer.storeDescriptor()
+                                        inst.vertexBufferIndex = render_vs
+                                                                     ? render_vs.storeDescriptor()
                                                                      : 0;
-                                        inst.indexBufferIndex = m.indexStorageBuffer
-                                                                    ? m.indexStorageBuffer.storeDescriptor()
+                                        inst.indexBufferIndex = render_is
+                                                                    ? render_is.storeDescriptor()
                                                                     : 0;
                                         inst.materialID = materialID;
                                         inst.objectID = object_id;
@@ -674,7 +729,7 @@ void OpticsSystem::optics_pipeline(float frame_count, uint64_t frame_index) {
                                         target_visibility[visibility_frag_glsl::pushConsts::textureIndex] =
                                             static_cast<uint32_t>(0);
                                     }
-                                    target_visibility.record(m.indexBuffer, m.vertexBuffer);
+                                    target_visibility.record(render_ib, render_vb);
                                 }
                             }
                             ++object_id;

--- a/src/systems/script/python/corona_engine_api.cpp
+++ b/src/systems/script/python/corona_engine_api.cpp
@@ -527,8 +527,11 @@ float Corona::API::Environment::get_fixed_dt() const {
 //         Geometry
 // ########################
 Corona::API::Geometry::Geometry(const std::string& model_path) {
+    // 保存路径供 Actor 标识和 GeometrySystem 资源加载/卸载使用
+    model_path_ = Utils::utf8_to_path(model_path);
+
     // 使用 utf8_to_path 确保 UTF-8 编码的路径在 Windows 上正确转换
-    auto model_id = Resource::ResourceManager::get_instance().import_sync(Utils::utf8_to_path(model_path));
+    auto model_id = Resource::ResourceManager::get_instance().import_sync(model_path_);
     if (model_id == 0) {
         CFW_LOG_CRITICAL("[Geometry::Geometry] Failed to load model: {}", model_path);
         return;
@@ -903,6 +906,10 @@ std::array<float, 3> Corona::API::Geometry::get_scale() const {
 
 std::uintptr_t Corona::API::Geometry::get_handle() const {
     return handle_;
+}
+
+const std::filesystem::path& Corona::API::Geometry::get_model_path() const {
+    return model_path_;
 }
 
 std::array<float, 6> Corona::API::Geometry::get_aabb() const {
@@ -1455,6 +1462,9 @@ Corona::API::Actor::Profile* Corona::API::Actor::add_profile(const Profile& prof
             if (storage_profile_handle != 0) {
                 accessor->profile_handles.push_back(storage_profile_handle);
             }
+            // 将 Geometry 的 model_path 同步到 ActorDevice，
+            // GeometrySystem 的 load/unload 路径依赖此字段
+            accessor->model_path = profile.geometry->get_model_path();
         } else {
             CFW_LOG_ERROR("[Actor::add_profile] Failed to acquire write access to actor storage");
         }


### PR DESCRIPTION
主要：
1.实现 upload_lod_from_scene_data()` 管线，从 meshoptimizer 数据创建多级 GPU 缓冲  
2.Actor GPU 资源释放与重建闭环                                               
  - release_actor_gpu_resources() — 卸载时释放 HardwareBuffer/HardwareImage                              
  - rebuild_actor_gpu_resources() — 重载时重建 GPU 缓冲与纹理
 3.完善 actor 加载/卸载闭环的资源管理 
部分bug：
  - 数据竞争：`simplification_cfg` 读写加锁                                                                
  - Stale cache：LOD 缓存改用 `model_id` 判重，防止 slot 复用误判                                          
  - 析构 crash：静态 `HardwareImage` 移入成员 `unique_ptr`，`shutdown()` 显式释放                          
  - 卸载丢失：`on_unload_requested` 在加载进行中不再静默丢弃，改为取消加载                                 
  - 状态机死锁：卸载 10 次重试耗尽后回退 `Loaded`，避免永久卡死
  
 注: 物体减面效果不理想，距离转化lod级别过于敏感，
        level.screen_threshold = (result_error > 0.0f) ? std::max(0.01f, 1.0f / (1.0f + result_error * 10.0f)) : 0.0f;  //parse_common.h
*10.0f导致只要不是完全贴近物体，稍微远离一点就会提高lod
此外球体的高级lod会畸形