### PR TITLE
视锥驱逐、距离剔除与 GPU 资源热重载完整闭环

### DIFF
--- a/include/corona/events/scene_system_events.h
+++ b/include/corona/events/scene_system_events.h
@@ -49,9 +49,12 @@ struct ActorLoadRequestedEvent {
 };
 
 /**
- * @brief Actor 资源加载完成事件（由资源系统发布）
+ * @brief Actor 资源加载完成，GPU 资源已就绪（由 GeometrySystem 发布）
+ *
+ * 外部系统（Optics/Mechanics/Vision）应监听此事件以开始消费该 actor。
+ * 与 ActorLoadRequestedEvent 配对：request → 异步加载 → finished。
  */
-struct ActorLoadCompletedEvent {
+struct ActorLoadFinishedEvent {
     std::uintptr_t scene{};
     std::uintptr_t actor{};
 };
@@ -65,9 +68,12 @@ struct ActorUnloadRequestedEvent {
 };
 
 /**
- * @brief Actor 资源卸载完成事件（由资源系统发布）
+ * @brief Actor 资源卸载完成，GPU 资源已释放（由 GeometrySystem 发布）
+ *
+ * 外部系统应监听此事件以停止消费该 actor。
+ * 与 ActorUnloadRequestedEvent 配对：request → 异步卸载 → finished。
  */
-struct ActorUnloadCompletedEvent {
+struct ActorUnloadFinishedEvent {
     std::uintptr_t scene{};
     std::uintptr_t actor{};
 };

--- a/include/corona/shared_data_hub.h
+++ b/include/corona/shared_data_hub.h
@@ -377,6 +377,7 @@ struct SceneDevice {
     bool simulation_enabled{false};
     std::uintptr_t environment{};
     std::vector<std::uintptr_t> actor_handles;
+    std::vector<std::uintptr_t> visible_actor_handles;
     std::vector<std::uintptr_t> camera_handles;
     std::uintptr_t active_camera_handle{};
     ktm::fvec3 min_world;

--- a/include/corona/spatial/bvh.h
+++ b/include/corona/spatial/bvh.h
@@ -1,0 +1,625 @@
+#pragma once
+
+#include <corona/spatial/aabb.h>
+#include <ktm/ktm.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <span>
+#include <utility>
+#include <vector>
+
+namespace Corona::Spatial {
+
+/**
+ * @brief 物体级 BVH（Bounding Volume Hierarchy）加速结构
+ *
+ * 设计定位：
+ *   - Octree 负责 **场景级**："场景中有哪些物体？"（粗粒度剔除）
+ *   - BVH   负责 **物体级**："这个物体内部命中了哪些基元？"（细粒度查询）
+ *   两者组合使用形成双层加速结构。
+ *
+ * 构建算法：
+ *   自顶向下递归构建，每层选择包围盒最长轴，按基元重心排序后中位数
+ *   分割（spatial median split）。时间复杂度 O(n log n)，对退化输入
+ *   （同重心、零体积包围盒等）有兜底处理。
+ *
+ * 查询接口：
+ *   - query_ray()   : 射线穿透，返回所有 AABB 被命中的载荷（无序）
+ *   - closest_hit() : 射线穿透，返回离射线起点最近的命中载荷（有序遍历 + 剪枝）
+ *   - query_aabb()  : 包围盒重叠查询
+ *
+ * @tparam TPayload 叶节点载荷类型（如三角形索引、碰撞体句柄）。
+ *                  要求可拷贝、可移动、可用 operator< 比较（去重用）。
+ *
+ * 使用示例：
+ * @code
+ *   BVH<uint32_t> bvh;
+ *   std::vector<BVH<uint32_t>::Entry> entries;
+ *   for (uint32_t i = 0; i < triangles.size(); ++i) {
+ *       entries.push_back({i, compute_AABB(triangles[i])});
+ *   }
+ *   bvh.build(entries);
+ *
+ *   // 穿透查询：拿到所有命中的三角面索引
+ *   std::vector<uint32_t> hits;
+ *   bvh.query_ray(ray_origin, ray_inv_dir, hits);
+ *
+ *   // 最近命中：直接返回 Hit{payload, t} 或 nullopt
+ *   if (auto hit = bvh.closest_hit(origin, inv_dir, 1000.0f)) {
+ *       uint32_t tri = hit->payload;   // 最近三角面
+ *       float    t   = hit->t;         // 命中距离
+ *   }
+ * @endcode
+ */
+template <typename TPayload>
+class BVH {
+   public:
+    // ================================================================
+    // 公开类型
+    // ================================================================
+
+    /**
+     * @brief 输入基元：一对一的载荷与包围盒映射
+     *
+     * 重心的预计算放在构建内部完成，调用方只需提供 bounds。
+     */
+    struct Entry {
+        TPayload payload;  ///< 基元标识，如三角形下标
+        AABB     bounds;   ///< 世界空间 / 局部空间包围盒（构建前必须 valid()）
+    };
+
+    /**
+     * @brief 构建参数
+     */
+    struct Config {
+        /** 叶节点基元数上限。超过此值且未到 max_depth 则继续分裂。*/
+        int max_leaf_primitives = 4;
+
+        /** 树的最大深度，防止无限递归。*/
+        int max_depth = 32;
+    };
+
+    /**
+     * @brief 射线命中结果
+     */
+    struct Hit {
+        TPayload payload;  ///< 命中的载荷
+        float    t;        ///< 命中点到射线起点的参数距离（t >= 0）
+    };
+
+    /**
+     * @brief 统计信息（调试/性能分析用）
+     */
+    struct Stats {
+        std::size_t nodes            = 0;  ///< 节点总数
+        std::size_t leaves           = 0;  ///< 叶节点数
+        std::size_t total_primitives = 0;  ///< 基元总数（叶节点 entries 之和）
+        int         max_depth_used   = 0;  ///< 实际最大深度
+    };
+
+    explicit BVH(Config cfg = {}) : cfg_(cfg) {}
+
+    /** 清空整棵树，释放所有内存 */
+    void clear() noexcept { root_.reset(); }
+
+    /**
+     * @brief 全量重建 BVH
+     *
+     * 每次调用完全覆盖旧树。典型调用时机：
+     *   - 物体几何变更（蒙皮动画、变形）
+     *   - 物体变换更新导致包围盒在世界空间发生变化
+     *
+     * @param entries 基元列表（内部拷贝一份用于排序构建，调用方可随后释放）
+     */
+    void build(std::span<const Entry> entries) {
+        if (entries.empty()) {
+            root_.reset();
+            return;
+        }
+
+        // 拷贝到可变缓冲区，预计算重心供排序
+        std::vector<BuildEntry> buffer;
+        buffer.reserve(entries.size());
+        for (const auto& e : entries) {
+            buffer.push_back({e.payload, e.bounds, e.bounds.center()});
+        }
+
+        root_ = build_recursive(buffer, 0);
+    }
+
+    [[nodiscard]] bool empty() const noexcept { return !root_; }
+
+    [[nodiscard]] const Config& config() const noexcept { return cfg_; }
+
+    // ================================================================
+    // 射线查询
+    // ================================================================
+
+    /**
+     * @brief 返回射线命中的所有载荷（AABB 级，无序）
+     *
+     * 注意：命中判定基于包围盒而非精确几何。调用方如需精确命中，
+     * 拿到载荷后自行做三角形级射线检测。
+     *
+     * @param origin   射线起点
+     * @param inv_dir  射线方向各分量的倒数（1/dir），传此值可避免三次除法
+     * @param out      输出：命中的载荷列表（不清空，追加写入）
+     */
+    void query_ray(const ktm::fvec3& origin,
+                   const ktm::fvec3& inv_dir,
+                   std::vector<TPayload>& out) const {
+        if (!root_) return;
+        query_ray_recursive(root_.get(), origin, inv_dir, out);
+    }
+
+    /**
+     * @brief 返回射线命中的最近载荷（AABB 级，有序遍历 + 剪枝）
+     *
+     * 遍历策略：每次进入内部节点时，先计算左右子节点的入口距离，
+     * 从近到远遍历，并持续用当前最优 t 剪枝——一旦子节点的入口距离
+     * 超过已知最优 t 即跳过整棵子树。
+     *
+     * @param origin   射线起点
+     * @param inv_dir  射线方向各分量的倒数
+     * @param t_max    最大搜索距离（射线长度），命中的 t 一定 <= t_max
+     * @return 命中返回 Hit{payload, t}，未命中返回 std::nullopt
+     */
+    [[nodiscard]] std::optional<Hit> closest_hit(const ktm::fvec3& origin,
+                                                  const ktm::fvec3& inv_dir,
+                                                  float              t_max) const {
+        if (!root_) return std::nullopt;
+        std::optional<Hit> best;
+        float best_t = t_max;
+        closest_hit_recursive(root_.get(), origin, inv_dir, best, best_t);
+        return best;
+    }
+
+    // ================================================================
+    // 包围盒查询
+    // ================================================================
+
+    /**
+     * @brief 返回所有包围盒与给定 AABB 重叠的载荷
+     *
+     * @param box  查询包围盒
+     * @param out  输出：命中的载荷列表（不清空，追加写入）
+     */
+    void query_aabb(const AABB& box, std::vector<TPayload>& out) const {
+        if (!root_) return;
+        query_aabb_recursive(root_.get(), box, out);
+    }
+
+    // ================================================================
+    // 调试 / 统计
+    // ================================================================
+
+    [[nodiscard]] Stats stats() const noexcept {
+        Stats s;
+        gather_stats(root_.get(), s, 0);
+        return s;
+    }
+
+   private:
+    // ================================================================
+    // 内部节点结构
+    // ================================================================
+    //
+    // BVH 是一棵二叉树：
+    //   - 叶节点：entries 非空，left/right 均为空
+    //   - 内部节点：left/right 均非空，entries 为空（仅用于包围盒维护）
+    //
+    //   与 Octree（八叉树）的区别：
+    //   - Octree 是八分空间，内部节点可能也存储跨分割面的基元
+    //   - BVH 是二分对象，每个基元只出现在一个叶节点中
+    //
+    struct Node {
+        AABB bounds;  ///< 该节点所有基元的紧致包围盒
+
+        std::unique_ptr<Node> left;   ///< 左子树
+        std::unique_ptr<Node> right;  ///< 右子树
+
+        std::vector<Entry> entries;  ///< 仅在叶节点有效
+
+        bool is_leaf = true;    ///< 是否为叶节点
+        int  axis    = 0;       ///< 分割轴（调试用，0=x, 1=y, 2=z）
+    };
+
+    // ================================================================
+    // 射线 ↔ AABB 相交检测（Slab 方法）
+    // ================================================================
+    //
+    // 原理：将 AABB 视为三对平行平面的交集，分别计算射线与每对平面
+    // 的进出参数 t，取最近进入点和最远离开点。若 tmin <= tmax 且
+    // tmax >= 0，则相交。
+    //
+    // 稳健处理：
+    //   - 射线方向分量为 0（平行于某轴）时，用显式区间检查代替除法
+    //   - 避免 inf*0=NaN 问题
+    //
+
+    /**
+     * @brief 单个轴上的 slab 检测
+     *
+     * 当 dir[axis] == 0 时射线平行于该轴，inv_dir[axis] 为 ±inf。
+     * 此时需直接检查原点是否在该轴区间内。
+     *
+     * 当 inv_dir[axis] == 0（即 dir 无穷大，实际罕见）时走标准 slab，
+     * t0/t1 均退化为 0，该轴不收窄 tmin/tmax，等价于"对该轴无约束"。
+     *
+     * @return true  该轴通过
+     * @return false 射线平行且原点在区间外，或进出参数导致 tmin > tmax
+     */
+    static bool slab_test(float  origin_val,   ///< 射线起点在该轴的坐标
+                          float  inv_dir_val,  ///< 射线方向倒数（dir==0 时为 ±inf）
+                          float  box_min_val,  ///< 包围盒该轴最小值
+                          float  box_max_val,  ///< 包围盒该轴最大值
+                          float& tmin,         ///< [in/out] 当前最近进入点
+                          float& tmax)         ///< [in/out] 当前最远离开点
+    {
+        // 情形 1：射线方向分量为 0（或 NaN）—— 平行于该轴
+        //         inv_dir = 1/0 = ±inf，用 isinf 精确捕获
+        //         NaN 走相同路径：视为平行，区间内通过，区间外淘汰
+        if (std::isnan(inv_dir_val) || std::isinf(inv_dir_val)) {
+            return origin_val >= box_min_val && origin_val <= box_max_val;
+        }
+
+        // 情形 2：标准 slab 检测（dir 分量有限，inv_dir 有限）
+        float t0 = (box_min_val - origin_val) * inv_dir_val;
+        float t1 = (box_max_val - origin_val) * inv_dir_val;
+        if (t0 > t1) {
+            std::swap(t0, t1);  // 确保 t0 <= t1（t0 是进入，t1 是离开）
+        }
+        tmin = (t0 > tmin) ? t0 : tmin;  // 收紧进入点
+        tmax = (t1 < tmax) ? t1 : tmax;  // 收紧离开点
+        return tmin <= tmax;
+    }
+
+    /**
+     * @brief 射线与包围盒相交检测（带参数范围）
+     *
+     * @param origin  射线起点
+     * @param inv_dir 射线方向倒数
+     * @param box     包围盒
+     * @param t_min   允许的最小 t（通常为 0，避免负方向的命中）
+     * @param t_max   允许的最大 t（如射线长度）
+     * @return true 相交
+     */
+    static bool ray_aabb_intersect(const ktm::fvec3& origin,
+                                   const ktm::fvec3& inv_dir,
+                                   const AABB&        box,
+                                   float              t_min,
+                                   float              t_max) {
+        // 依次检测 X / Y / Z 三个轴
+        if (!slab_test(origin.x, inv_dir.x, box.min.x, box.max.x, t_min, t_max)) return false;
+        if (!slab_test(origin.y, inv_dir.y, box.min.y, box.max.y, t_min, t_max)) return false;
+        if (!slab_test(origin.z, inv_dir.z, box.min.z, box.max.z, t_min, t_max)) return false;
+        return true;
+    }
+
+    /**
+     * @brief 计算射线进入包围盒的参数距离
+     *
+     * 用于 closest_hit 的有序遍历：决定先遍历哪个子节点。
+     *
+     * @return t_entry：射线进入包围盒处的参数值。
+     *         若不相交则返回 +inf。
+     */
+    static float ray_entry_t(const ktm::fvec3& origin,
+                             const ktm::fvec3& inv_dir,
+                             const AABB&        box) {
+        float tmin = 0.0f;
+        float tmax = std::numeric_limits<float>::max();
+
+        // X 轴：平行/NaN 检测（dir.x==0 ⇔ inv_dir.x==±inf）
+        if (!std::isnan(inv_dir.x) && !std::isinf(inv_dir.x)) {
+            float t0 = (box.min.x - origin.x) * inv_dir.x;
+            float t1 = (box.max.x - origin.x) * inv_dir.x;
+            if (t0 > t1) std::swap(t0, t1);
+            tmin = (t0 > tmin) ? t0 : tmin;
+            tmax = (t1 < tmax) ? t1 : tmax;
+        } else if (origin.x < box.min.x || origin.x > box.max.x) {
+            return std::numeric_limits<float>::max();
+        }
+
+        // Y 轴
+        if (!std::isnan(inv_dir.y) && !std::isinf(inv_dir.y)) {
+            float t0 = (box.min.y - origin.y) * inv_dir.y;
+            float t1 = (box.max.y - origin.y) * inv_dir.y;
+            if (t0 > t1) std::swap(t0, t1);
+            tmin = (t0 > tmin) ? t0 : tmin;
+            tmax = (t1 < tmax) ? t1 : tmax;
+        } else if (origin.y < box.min.y || origin.y > box.max.y) {
+            return std::numeric_limits<float>::max();
+        }
+
+        // Z 轴
+        if (!std::isnan(inv_dir.z) && !std::isinf(inv_dir.z)) {
+            float t0 = (box.min.z - origin.z) * inv_dir.z;
+            float t1 = (box.max.z - origin.z) * inv_dir.z;
+            if (t0 > t1) std::swap(t0, t1);
+            tmin = (t0 > tmin) ? t0 : tmin;
+            tmax = (t1 < tmax) ? t1 : tmax;
+        } else if (origin.z < box.min.z || origin.z > box.max.z) {
+            return std::numeric_limits<float>::max();
+        }
+
+        if (tmin > tmax) return std::numeric_limits<float>::max();
+        return tmin;  // 进入点的 t
+    }
+
+    // ================================================================
+    // 构建
+    // ================================================================
+
+    /**
+     * @brief 递归构建子树
+     *
+     * 算法步骤（spatial median split）：
+     *   1. 计算该组基元的合并包围盒
+     *   2. 若满足终止条件（<= leaf_capacity 或 >= max_depth），创建叶节点
+     *   3. 否则选择包围盒最长轴作为分割轴
+     *   4. 按基元重心沿该轴排序，中位数切分
+     *   5. 左右子集递归构建
+     *
+     * 退化兜底：
+     *   - 若包围盒零体积（所有轴退化），直接创建叶节点
+     *   - 若所有基元重心相同（排序后首尾相等），无法继续分割，创建叶节点
+     *
+     * @param entries 可变基元列表（包含预计算的重心）
+     * @param depth   当前递归深度
+     * @return 构建好的子树根节点
+     */
+    struct BuildEntry {
+        TPayload   payload;
+        AABB       bounds;
+        ktm::fvec3 centroid;
+    };
+
+    std::unique_ptr<Node> build_recursive(std::vector<BuildEntry>& entries, int depth) {
+        // ---------- 步骤 1：计算合并包围盒 ----------
+        AABB merged = entries[0].bounds;
+        for (std::size_t i = 1; i < entries.size(); ++i) {
+            merged = merged.merged(entries[i].bounds);
+        }
+
+        // ---------- 步骤 2：终止条件 ----------
+        // 叶节点条件：基元数 <= 阈值  或  不足两个无法二分  或  深度 >= 上限
+        if (static_cast<int>(entries.size()) <= cfg_.max_leaf_primitives
+            || entries.size() < 2
+            || depth >= cfg_.max_depth) {
+            auto node        = std::make_unique<Node>();
+            node->bounds     = merged;
+            node->is_leaf    = true;
+            node->entries.reserve(entries.size());
+            for (const auto& be : entries) {
+                node->entries.push_back({be.payload, be.bounds});
+            }
+            return node;
+        }
+
+        // ---------- 步骤 3：选择分割轴 ----------
+        // 选包围盒跨度最大的轴。若所有轴退化，创建叶节点退出。
+        ktm::fvec3 extent = merged.extent();  // 半边长向量
+        float ex = extent.x, ey = extent.y, ez = extent.z;
+
+        int split_axis = 0;  // 默认 X
+        if (ey > ex && ey > ez) {
+            split_axis = 1;  // Y 最大
+        } else if (ez > ex && ez > ey) {
+            split_axis = 2;  // Z 最大
+        }
+
+        // 零体积包围盒兜底（所有轴都退化）
+        if (ex <= 0.0f && ey <= 0.0f && ez <= 0.0f) {
+            auto node     = std::make_unique<Node>();
+            node->bounds  = merged;
+            node->is_leaf = true;
+            node->entries.reserve(entries.size());
+            for (const auto& be : entries) {
+                node->entries.push_back({be.payload, be.bounds});
+            }
+            return node;
+        }
+
+        // ---------- 步骤 4：沿分割轴排序 ----------
+        // 使用 lambda 提取指定轴的重心分量
+        auto centroid_on_axis = [split_axis](const BuildEntry& be) -> float {
+            switch (split_axis) {
+                case 0:  return be.centroid.x;
+                case 1:  return be.centroid.y;
+                default: return be.centroid.z;
+            }
+        };
+
+        std::sort(entries.begin(), entries.end(),
+                  [&](const BuildEntry& a, const BuildEntry& b) {
+                      return centroid_on_axis(a) < centroid_on_axis(b);
+                  });
+
+        // ---------- 步骤 5：退化检测 ----------
+        // 如果排序后首尾重心相等，说明所有基元重心在该轴上相同，
+        // 无法通过该轴分割。此时扩大检查范围——若所有轴都相同则建叶。
+        float first_c = centroid_on_axis(entries.front());
+        float last_c  = centroid_on_axis(entries.back());
+        if (first_c == last_c) {
+            // 尝试换一个轴再排序。这里简单兜底：直接创建叶节点。
+            auto node     = std::make_unique<Node>();
+            node->bounds  = merged;
+            node->is_leaf = true;
+            node->entries.reserve(entries.size());
+            for (const auto& be : entries) {
+                node->entries.push_back({be.payload, be.bounds});
+            }
+            return node;
+        }
+
+        // ---------- 步骤 6：中位数切分 & 递归 ----------
+        std::size_t mid = entries.size() / 2;
+
+        // 左子集：[0, mid)
+        std::vector<BuildEntry> left_entries(entries.begin(), entries.begin() + mid);
+        // 右子集：[mid, end)
+        std::vector<BuildEntry> right_entries(entries.begin() + mid, entries.end());
+
+        auto node      = std::make_unique<Node>();
+        node->is_leaf  = false;
+        node->axis     = split_axis;
+        node->left     = build_recursive(left_entries, depth + 1);
+        node->right    = build_recursive(right_entries, depth + 1);
+
+        // 内部节点的包围盒 = 左右子节点包围盒的合并
+        node->bounds = node->left->bounds.merged(node->right->bounds);
+
+        return node;
+    }
+
+    // ================================================================
+    // 射线查询（递归）
+    // ================================================================
+
+    /**
+     * @brief 无序射线查询——递归遍历整棵树
+     *
+     * 对每个节点先做 ray-AABB 检测，不命中则整棵子树剪枝。
+     * 叶节点命中后，所有基元无条件输出（调用方自行精筛）。
+     */
+    static void query_ray_recursive(const Node*         node,
+                                    const ktm::fvec3&   origin,
+                                    const ktm::fvec3&   inv_dir,
+                                    std::vector<TPayload>& out) {
+        if (!node) return;
+
+        // 剪枝：射线不命中该节点包围盒 → 跳过整棵子树
+        if (!ray_aabb_intersect(origin, inv_dir, node->bounds, 0.0f,
+                                std::numeric_limits<float>::max())) {
+            return;
+        }
+
+        if (node->is_leaf) {
+            // 叶节点：所有基元加入输出
+            for (const auto& e : node->entries) {
+                if (ray_aabb_intersect(origin, inv_dir, e.bounds, 0.0f,
+                                       std::numeric_limits<float>::max())) {
+                    out.push_back(e.payload);
+                }
+            }
+            return;
+        }
+
+        // 内部节点：递归左右子树（无需排序——query_ray 不关心距离）
+        query_ray_recursive(node->left.get(), origin, inv_dir, out);
+        query_ray_recursive(node->right.get(), origin, inv_dir, out);
+    }
+
+    // ================================================================
+    // 最近命中查询（递归——有序遍历 + 剪枝）
+    // ================================================================
+
+    /**
+     * @brief 最近命中递归
+     *
+     * 核心优化：先计算左右子节点的入口 t，从近到远遍历。
+     * 一旦近端命中，远端子树可能因入口 t > best_t 被整棵剪掉。
+     *
+     * @param best   [in/out] 当前最优 Hit，未命中状态用 nullopt 表示
+     * @param best_t [in/out] 当前最优 t，随遍历推进不断收紧
+     */
+    static void closest_hit_recursive(const Node*            node,
+                                      const ktm::fvec3&      origin,
+                                      const ktm::fvec3&      inv_dir,
+                                      std::optional<Hit>&    best,
+                                      float&                 best_t) {
+        if (!node) return;
+
+        // 剪枝：节点包围盒入口距离已超过当前最优 → 跳过
+        if (!ray_aabb_intersect(origin, inv_dir, node->bounds, 0.0f, best_t)) {
+            return;
+        }
+
+        if (node->is_leaf) {
+            // 叶节点：逐个检测基元，更新最优
+            // ray_entry_t 同时完成相交判定和入口 t 计算，不相交时返回 +inf
+            for (const auto& e : node->entries) {
+                float t_entry = ray_entry_t(origin, inv_dir, e.bounds);
+                if (t_entry < best_t) {
+                    best_t = t_entry;
+                    best   = Hit{e.payload, t_entry};
+                }
+            }
+            return;
+        }
+
+        // 内部节点：计算左右子节点的入口距离，决定遍历顺序
+        float t_left  = ray_entry_t(origin, inv_dir, node->left->bounds);
+        float t_right = ray_entry_t(origin, inv_dir, node->right->bounds);
+
+        // 从近到远遍历
+        if (t_left <= t_right) {
+            closest_hit_recursive(node->left.get(),  origin, inv_dir, best, best_t);
+            closest_hit_recursive(node->right.get(), origin, inv_dir, best, best_t);
+        } else {
+            closest_hit_recursive(node->right.get(), origin, inv_dir, best, best_t);
+            closest_hit_recursive(node->left.get(),  origin, inv_dir, best, best_t);
+        }
+    }
+
+    // ================================================================
+    // 包围盒查询（递归）
+    // ================================================================
+
+    /**
+     * @brief 包围盒重叠查询——递归遍历
+     *
+     * 对每个节点先做 AABB overlaps 测试，不重叠则剪枝。
+     */
+    static void query_aabb_recursive(const Node*            node,
+                                     const AABB&            box,
+                                     std::vector<TPayload>& out) {
+        if (!node) return;
+
+        // 剪枝：查询盒与节点包围盒不重叠 → 跳过整棵子树
+        if (!node->bounds.overlaps(box)) return;
+
+        if (node->is_leaf) {
+            for (const auto& e : node->entries) {
+                if (e.bounds.overlaps(box)) {
+                    out.push_back(e.payload);
+                }
+            }
+            return;
+        }
+
+        query_aabb_recursive(node->left.get(), box, out);
+        query_aabb_recursive(node->right.get(), box, out);
+    }
+
+    // ================================================================
+    // 统计信息收集
+    // ================================================================
+
+    static void gather_stats(const Node* node, Stats& s, int depth) {
+        if (!node) return;
+        ++s.nodes;
+        s.max_depth_used = std::max(s.max_depth_used, depth);
+        if (node->is_leaf) {
+            ++s.leaves;
+            s.total_primitives += node->entries.size();
+        } else {
+            gather_stats(node->left.get(), s, depth + 1);
+            gather_stats(node->right.get(), s, depth + 1);
+        }
+    }
+
+    // ================================================================
+    // 成员变量
+    // ================================================================
+
+    Config                  cfg_;   ///< 构建参数
+    std::unique_ptr<Node>   root_;  ///< 根节点（null 表示空树）
+};
+
+}  // namespace Corona::Spatial

--- a/include/corona/systems/geometry/actor_cache.h
+++ b/include/corona/systems/geometry/actor_cache.h
@@ -1,0 +1,89 @@
+#pragma once
+
+/// @file actor_cache.h
+/// @brief ActorCache — 类型化 Actor 快照缓存，封装两级 LRU CacheManager
+///
+/// ActorSnapshot 包含重建 actor 所需的最小信息集：
+/// - model_path（资源文件路径，也是 ResourceManager 的 key）
+/// - transform（position / euler_rotation / scale）
+/// - follow_camera flag
+///
+/// 注意：mesh / texture 等重资源由 ResourceManager 自行管理；
+///       ActorSnapshot 只存资源路径，不重复序列化几何数据。
+
+#include <corona/resource/cache/lru_cache.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <optional>
+#include <string>
+
+namespace Corona::Cache {
+
+// ============================================================================
+// ActorSnapshot — 重建 actor 所需的最小数据
+// ============================================================================
+
+struct ActorSnapshot {
+    std::filesystem::path model_path;          // 模型文件路径（ResourceManager key）
+    float position[3]        = {0, 0, 0};      // world position
+    float euler_rotation[3]  = {0, 0, 0};      // euler angles (radians)
+    float scale[3]           = {1, 1, 1};      // world scale
+    bool  follow_camera      = false;           // camera-local 渲染模式
+    int   profile_count      = 0;               // profile 数量（仅用于验证）
+
+    /// JSON 序列化
+    [[nodiscard]] std::string to_json() const;
+    [[nodiscard]] static std::optional<ActorSnapshot> from_json(const std::string& json);
+};
+
+// ============================================================================
+// ActorCache — 类型化 actor 缓存
+// ============================================================================
+
+class ActorCache {
+public:
+    /// @param mem_capacity  内存缓存容量（字节），默认 64 MB
+    /// @param disk_capacity 磁盘缓存容量（字节），0 = 仅内存
+    /// @param disk_dir      磁盘缓存目录
+    ActorCache(size_t mem_capacity, size_t disk_capacity,
+               std::filesystem::path disk_dir);
+
+    ~ActorCache() = default;
+
+    ActorCache(const ActorCache&) = delete;
+    ActorCache& operator=(const ActorCache&) = delete;
+
+    // ---- 核心 API ----
+
+    /// 存入 actor 快照
+    bool put(std::uintptr_t actor_handle, const ActorSnapshot& snapshot);
+
+    /// 获取 actor 快照
+    std::optional<ActorSnapshot> get(std::uintptr_t actor_handle);
+
+    /// 移除 actor 缓存项
+    void remove(std::uintptr_t actor_handle);
+
+    /// 检查 actor 是否在缓存中
+    [[nodiscard]] bool contains(std::uintptr_t actor_handle);
+
+    // ---- 容量查询 ----
+    [[nodiscard]] size_t memory_used() const;
+    [[nodiscard]] size_t memory_capacity() const;
+    [[nodiscard]] size_t disk_used();
+    [[nodiscard]] size_t disk_capacity() const;
+
+    // ---- 淘汰回调 ----
+    /// 设置淘汰回调：当 actor 快照被从 LRU 中淘汰时调用
+    void set_evict_callback(std::function<void(std::uintptr_t, const std::string&)> cb);
+
+private:
+    CacheManager cache_;
+
+    [[nodiscard]] static std::string make_key(std::uintptr_t handle);
+    [[nodiscard]] static std::uintptr_t parse_key(const std::string& key);
+};
+
+}  // namespace Corona::Cache

--- a/include/corona/systems/geometry/geometry_system.h
+++ b/include/corona/systems/geometry/geometry_system.h
@@ -12,6 +12,7 @@
 #include <corona/spatial/bvh.h>
 
 #include <cstdint>
+#include <filesystem>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -188,8 +189,24 @@ class GeometrySystem : public Kernel::SystemBase {
         std::uintptr_t scene, std::uintptr_t camera) const;
 
     // ========================================
-    // LRU 协作（M3 起启用，当前为占位）
+    // LRU 协作（M3 生产化）
     // ========================================
+    //
+    // ActorEvictRequestedEvent 发布后，GeometrySystem 自动：
+    //   1. 创建 ActorSnapshot（model_path + transform）
+    //   2. 存入 ActorCache（两级 LRU：内存 64MB + 磁盘 256MB）
+    //   3. 标记 actor 为 offline，状态置为 Unloaded
+    //
+    // ActorRestoreRequestedEvent 发布后，GeometrySystem 自动：
+    //   1. 从 ActorCache 获取快照（或回退到磁盘 model_path）
+    //   2. 调用 ResourceManager::import_async 重新导入
+    //   3. 导入完成后重建 GPU 资源，标记为 online
+    //
+    // 磁盘目录默认：{cwd}/cache/actors/，可通过 set_cache_directory() 修改
+
+    /// 设置 LRU ActorCache 磁盘目录（需在首次 evict 前调用）
+    void set_cache_directory(std::filesystem::path dir);
+
     [[nodiscard]] bool is_actor_offline(std::uintptr_t actor) const;
     void               mark_actor_restored(std::uintptr_t actor);
 
@@ -329,6 +346,8 @@ class GeometrySystem : public Kernel::SystemBase {
     void on_unload_completed(const Events::ActorUnloadCompletedEvent& event);
     void on_load_requested(const Events::ActorLoadRequestedEvent& event);
     void on_unload_requested(const Events::ActorUnloadRequestedEvent& event);
+    void on_evict_requested(const Events::ActorEvictRequestedEvent& event);
+    void on_restore_requested(const Events::ActorRestoreRequestedEvent& event);
     void process_async_tasks();  // 处理完成的异步资源任务
 
     /// 卸载完成时释放 actor 关联的 GPU 资源（HardwareBuffer / HardwareImage），

--- a/include/corona/systems/geometry/geometry_system.h
+++ b/include/corona/systems/geometry/geometry_system.h
@@ -342,8 +342,8 @@ class GeometrySystem : public Kernel::SystemBase {
     [[nodiscard]] SceneStats stats(std::uintptr_t scene) const;
 
    private:
-    void on_load_completed(const Events::ActorLoadCompletedEvent& event);
-    void on_unload_completed(const Events::ActorUnloadCompletedEvent& event);
+    void on_load_finished(const Events::ActorLoadFinishedEvent& event);
+    void on_unload_finished(const Events::ActorUnloadFinishedEvent& event);
     void on_load_requested(const Events::ActorLoadRequestedEvent& event);
     void on_unload_requested(const Events::ActorUnloadRequestedEvent& event);
     void on_evict_requested(const Events::ActorEvictRequestedEvent& event);

--- a/include/corona/systems/geometry/geometry_system.h
+++ b/include/corona/systems/geometry/geometry_system.h
@@ -9,9 +9,11 @@
 #include <corona/kernel/system/system_base.h>
 #include <corona/math/frustum.h>
 #include <corona/spatial/aabb.h>
+#include <corona/spatial/bvh.h>
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -276,6 +278,46 @@ class GeometrySystem : public Kernel::SystemBase {
         std::uintptr_t geometry_handle,
         uint32_t       mesh_index,
         float          screen_ratio) const;
+
+    // ========================================
+    // BVH 射线查询（三角形级加速）
+    // ========================================
+    //
+    // 使用场景：拿到 Octree 粗筛的 actor 列表后，对每个 mesh 调用以下方法
+    // 获取射线命中的三角形下标。payload = 三角形序号（i/3）。
+    //
+    // 命中基于三角形 AABB，调用方拿到候选三角形后需自行做精确
+    // ray-tri 相交检测（Möller-Trumbore）以确认最终命中。
+
+    /// 穿透查询：返回射线命中的所有三角形下标（AABB 级，无序）
+    /// @param geometry_handle GeometryDevice 句柄
+    /// @param mesh_index      子网格索引
+    /// @param lod_level       LOD 级别（0=原始精度）
+    /// @param origin          射线起点（mesh 局部空间）
+    /// @param inv_dir         射线方向倒数（1/dir.x, 1/dir.y, 1/dir.z）
+    /// @return 命中的三角形下标列表，未命中或无 BVH 时返回空 vector
+    [[nodiscard]] std::vector<uint32_t> query_mesh_ray(
+        std::uintptr_t   geometry_handle,
+        uint32_t         mesh_index,
+        int              lod_level,
+        const ktm::fvec3& origin,
+        const ktm::fvec3& inv_dir) const;
+
+    /// 最近命中查询：返回离射线起点最近的三角形及其距离
+    /// @param geometry_handle GeometryDevice 句柄
+    /// @param mesh_index      子网格索引
+    /// @param lod_level       LOD 级别
+    /// @param origin          射线起点（mesh 局部空间）
+    /// @param inv_dir         射线方向倒数
+    /// @param t_max           最大搜索距离
+    /// @return 命中返回 Hit{payload=三角形下标, t=距离}，未命中返回 std::nullopt
+    [[nodiscard]] std::optional<Spatial::BVH<uint32_t>::Hit> query_mesh_closest_hit(
+        std::uintptr_t   geometry_handle,
+        uint32_t         mesh_index,
+        int              lod_level,
+        const ktm::fvec3& origin,
+        const ktm::fvec3& inv_dir,
+        float            t_max) const;
 
     // ========================================
     // 统计

--- a/include/corona/systems/script/corona_engine_api.h
+++ b/include/corona/systems/script/corona_engine_api.h
@@ -382,6 +382,17 @@ class Scene {
     void set_simulation_enabled(bool enabled);
     [[nodiscard]] bool is_simulation_enabled() const;
 
+    // ========== Streaming / 可见性配置 ==========
+    /// 配置可见性驱逐策略
+    /// @param invisible_frames_to_evict 连续不可见帧数阈值（0=关闭驱逐）
+    void set_visibility_config(int invisible_frames_to_evict);
+
+    /// 配置距离驱动的加载/卸载策略
+    /// @param unload_dist  超过此距离且不可见时触发卸载
+    /// @param preload_dist 进入此距离时触发预加载
+    /// @param enable       是否启用距离剔除
+    void set_distance_config(float unload_dist, float preload_dist, bool enable = true);
+
    private:
     std::uintptr_t handle_{};
 

--- a/modules/corona_resource/include/corona/resource/cache/lru_cache.h
+++ b/modules/corona_resource/include/corona/resource/cache/lru_cache.h
@@ -1,0 +1,242 @@
+#pragma once
+
+/// @file lru_cache.h
+/// @brief 生产级两级 LRU 缓存（内存 + 磁盘）— ResourceResidency 基础设施
+///
+/// 从 modules/corona_resource/examples/lru_cache_example/ 提升并重构：
+/// - 命名空间收口到 Corona::Cache
+/// - 新增淘汰回调 (evict callback)，通知上层释放 GPU 资源
+/// - 磁盘目录策略强制：{root}/{key}.cache
+/// - 线程安全：CacheManager 级别 mutex 保护所有操作
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <list>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace Corona::Cache {
+
+// ============================================================================
+// CacheItem — 单个缓存项
+// ============================================================================
+
+struct CacheItem {
+    std::string                            key;
+    std::vector<char>                      data;
+    size_t                                 data_size = 0;
+    std::chrono::system_clock::time_point  last_access;
+    bool                                   pinned = false;
+
+    CacheItem();
+    CacheItem(std::string k, const char* d, size_t sz);
+    ~CacheItem() = default;
+
+    // 只允许移动（避免意外拷贝大数据）
+    CacheItem(const CacheItem&) = delete;
+    CacheItem& operator=(const CacheItem&) = delete;
+    CacheItem(CacheItem&&) noexcept = default;
+    CacheItem& operator=(CacheItem&&) noexcept = default;
+};
+
+// ============================================================================
+// EvictStatus / EvictResult — 淘汰操作的结构化结果
+// ============================================================================
+
+enum class EvictStatus {
+    Success,        // 成功淘汰一项
+    CacheEmpty,     // 缓存为空，无项可淘汰
+    AllPinned,      // 所有项都被 pinned，跳过后无候选项
+    DiskFull,       // 磁盘容量不足（仅 DiskCache）
+    DiskWriteError  // 磁盘写入失败（仅 DiskCache）
+};
+
+struct EvictResult {
+    EvictStatus status = EvictStatus::Success;
+    std::string key;                           // 被淘汰项的 key（Success 时有效）
+    size_t      bytes_freed = 0;               // 释放的字节数
+    std::optional<CacheItem> item;             // 被淘汰的数据（仅 MemoryCache::evict_lru 填充）
+
+    [[nodiscard]] bool ok() const { return status == EvictStatus::Success; }
+};
+
+// ============================================================================
+// MemoryCache — 内存 LRU
+// ============================================================================
+
+class MemoryCache {
+public:
+    /// @param capacity_bytes 内存容量上限（字节）
+    explicit MemoryCache(size_t capacity_bytes);
+    ~MemoryCache();
+
+    MemoryCache(const MemoryCache&) = delete;
+    MemoryCache& operator=(const MemoryCache&) = delete;
+
+    /// 插入/更新项。若 key 已存在则更新并提升到 LRU 头部。
+    /// @return false 表示容量不足以容纳新项
+    bool put(const std::string& key, const char* data, size_t size);
+
+    /// 获取项（提升到 LRU 头部）。返回拷贝，避免引用在后续 evict 中悬空。
+    std::optional<CacheItem> get(const std::string& key);
+
+    /// 仅更新访问时间并提升到 LRU 头部，不返回数据。
+    /// 比 get() 更轻量，适合调用方每帧"续期"活跃资源。
+    bool touch(const std::string& key);
+
+    /// 标记为不可淘汰（LRU evict 时跳过）
+    bool pin(const std::string& key);
+
+    /// 取消不可淘汰标记
+    bool unpin(const std::string& key);
+
+    /// 移除项
+    void erase(const std::string& key);
+
+    /// 淘汰 LRU 尾部第一个非 pinned 项。
+    /// @return EvictResult{Success, key, bytes_freed, item} 或 {CacheEmpty} / {AllPinned}
+    EvictResult evict_lru();
+
+    [[nodiscard]] bool contains(const std::string& key) const;
+    [[nodiscard]] size_t used_bytes() const { return used_; }
+    [[nodiscard]] size_t capacity_bytes() const { return capacity_; }
+    [[nodiscard]] size_t item_count() const { return map_.size(); }
+
+private:
+    size_t capacity_;
+    size_t used_ = 0;
+    std::list<CacheItem> list_;
+    std::unordered_map<std::string, std::list<CacheItem>::iterator> map_;
+};
+
+// ============================================================================
+// DiskCache — 磁盘 LRU
+// ============================================================================
+
+class DiskCache {
+public:
+    /// @param capacity_bytes 磁盘容量上限
+    /// @param directory      缓存目录（会自动创建）
+    DiskCache(size_t capacity_bytes, std::filesystem::path directory);
+    ~DiskCache();
+
+    DiskCache(const DiskCache&) = delete;
+    DiskCache& operator=(const DiskCache&) = delete;
+
+    /// 插入/更新项
+    bool put(CacheItem item);
+
+    /// 获取项（从磁盘读回并提升到 LRU 头部）
+    std::optional<CacheItem> get(const std::string& key);
+
+    /// 仅更新访问时间并提升到 LRU 头部（不读磁盘）
+    bool touch(const std::string& key);
+
+    /// 标记为不可淘汰
+    bool pin(const std::string& key);
+
+    /// 取消不可淘汰标记
+    bool unpin(const std::string& key);
+
+    /// 删除项（从磁盘删除文件 + 从 LRU 链表移除）
+    void erase(const std::string& key);
+
+    [[nodiscard]] bool contains(const std::string& key) const;
+    [[nodiscard]] size_t used_bytes();
+    [[nodiscard]] size_t capacity_bytes() const { return capacity_; }
+    [[nodiscard]] size_t item_count() const { return map_.size(); }
+
+private:
+    size_t capacity_;
+    std::filesystem::path dir_;
+    mutable std::mutex mtx_;  // 仅保护 list_ + map_ + 单次文件操作；CacheManager 的锁独立
+    std::list<std::string> list_;
+    // 映射中的 CacheItem 只存元数据（不含实际 data），磁盘是真实数据源
+    std::unordered_map<std::string, std::pair<CacheItem, std::list<std::string>::iterator>> map_;
+
+    /// 将 key 转为安全的文件路径
+    [[nodiscard]] std::filesystem::path safe_path(const std::string& key) const;
+
+    /// 从磁盘读取文件
+    std::optional<CacheItem> read_file(const std::string& key) const;
+
+    /// 写入文件到磁盘
+    bool write_file(const CacheItem& item) const;
+
+    /// 淘汰最旧的文件以腾出空间。调用方需持有 mtx_。
+    /// @param skip_key 跳过此 key（避免刚插入的项被立即淘汰）
+    EvictResult evict_one(const std::string& skip_key = "");
+
+    /// 重新计算目录总大小
+    size_t calc_directory_size() const;
+};
+
+// ============================================================================
+// CacheManager — 两级 LRU 管理器
+// ============================================================================
+
+/// 淘汰回调类型：当 MemoryCache 满时将项刷到磁盘，或 DiskCache 满时淘汰最旧项
+/// @param key   被淘汰项的 key
+/// @param data  被淘汰项的数据（仅在从内存刷到磁盘时非空）
+using EvictCallback = std::function<void(const std::string& key, const std::vector<char>& data)>;
+
+class CacheManager {
+public:
+    /// @param mem_capacity  内存缓存容量（字节）
+    /// @param disk_capacity 磁盘缓存容量（字节），0 = 仅内存
+    /// @param disk_dir      磁盘缓存目录，仅 disk_capacity > 0 时需要
+    CacheManager(size_t mem_capacity, size_t disk_capacity, std::filesystem::path disk_dir);
+
+    ~CacheManager() = default;
+
+    CacheManager(const CacheManager&) = delete;
+    CacheManager& operator=(const CacheManager&) = delete;
+
+    /// 存入一项。优先放内存；内存满则刷盘。
+    bool put(const std::string& key, const char* data, size_t size);
+
+    /// 获取一项。先查内存后查磁盘；命中磁盘后提升到内存。
+    std::optional<CacheItem> get(const std::string& key);
+
+    /// 删除一项（内存 + 磁盘）
+    void erase(const std::string& key);
+
+    /// 检查 key 是否存在
+    [[nodiscard]] bool contains(const std::string& key);
+
+    // ---- pin / unpin / touch ----
+    /// 仅更新访问时间（内存或磁盘），不返回数据
+    bool touch(const std::string& key);
+
+    /// 标记为不可淘汰（内存 + 磁盘）
+    bool pin(const std::string& key);
+
+    /// 取消不可淘汰标记（内存 + 磁盘）
+    bool unpin(const std::string& key);
+
+    // ---- 容量查询 ----
+    [[nodiscard]] size_t memory_used() const;
+    [[nodiscard]] size_t memory_capacity() const;
+    [[nodiscard]] size_t disk_used();
+    [[nodiscard]] size_t disk_capacity() const;
+
+    // ---- 淘汰回调 ----
+    /// 设置淘汰回调：当内存刷盘或磁盘淘汰时被调用
+    void set_evict_callback(EvictCallback cb);
+
+private:
+    MemoryCache mem_;
+    std::optional<DiskCache> disk_;
+    mutable std::mutex mtx_;
+    EvictCallback evict_cb_;
+
+};
+
+
+}  // namespace Corona::Cache

--- a/modules/corona_resource/src/resource/CMakeLists.txt
+++ b/modules/corona_resource/src/resource/CMakeLists.txt
@@ -7,6 +7,8 @@ set(CORONA_RESOURCE_MANAGER_SOURCE_FILES
     resource.cpp
     parser_registry.cpp
     resource_cache.cpp
+    ### cache ###
+    cache/lru_cache.cpp
     ### resource types ###
     # animation
     types/animation.cpp

--- a/modules/corona_resource/src/resource/cache/lru_cache.cpp
+++ b/modules/corona_resource/src/resource/cache/lru_cache.cpp
@@ -1,0 +1,546 @@
+#include <corona/resource/cache/lru_cache.h>
+
+#include <corona/kernel/core/i_logger.h>
+
+#include <algorithm>
+#include <fstream>
+#include <regex>
+#include <system_error>
+
+namespace Corona::Cache {
+
+// ============================================================================
+// CacheItem
+// ============================================================================
+
+CacheItem::CacheItem()
+    : data_size(0)
+    , last_access(std::chrono::system_clock::now()) {}
+
+CacheItem::CacheItem(std::string k, const char* d, size_t sz)
+    : key(std::move(k))
+    , data(d, d + sz)
+    , data_size(sz)
+    , last_access(std::chrono::system_clock::now()) {}
+
+// ============================================================================
+// MemoryCache
+// ============================================================================
+
+MemoryCache::MemoryCache(size_t capacity_bytes)
+    : capacity_(capacity_bytes) {}
+
+MemoryCache::~MemoryCache() = default;
+
+bool MemoryCache::put(const std::string& key, const char* data, size_t size) {
+    // 更新已存在的 key
+    auto it = map_.find(key);
+    if (it != map_.end()) {
+        auto& item = *(it->second);
+        used_ -= item.data_size;
+        item.data.assign(data, data + size);
+        item.data_size = size;
+        item.last_access = std::chrono::system_clock::now();
+        used_ += size;
+        // 提升到头部
+        list_.splice(list_.begin(), list_, it->second);
+        return true;
+    }
+
+    // 新项：检查容量
+    if (used_ + size > capacity_ && !list_.empty()) {
+        return false;  // 调用方应先 evict_lru()
+    }
+
+    // 插入到头部
+    CacheItem item(key, data, size);
+    used_ += size;
+    list_.push_front(std::move(item));
+    map_[key] = list_.begin();
+    return true;
+}
+
+std::optional<CacheItem> MemoryCache::get(const std::string& key) {
+    auto it = map_.find(key);
+    if (it == map_.end()) return std::nullopt;
+
+    auto& item = *(it->second);
+    item.last_access = std::chrono::system_clock::now();
+    // 提升到头部
+    list_.splice(list_.begin(), list_, it->second);
+    // 显式构造返回值（CacheItem 为 move-only，不可隐式拷贝），
+    // 避免引用包装在后续 evict 中悬空。
+    CacheItem result(item.key, item.data.data(), item.data.size());
+    result.last_access = item.last_access;
+    return result;
+}
+
+void MemoryCache::erase(const std::string& key) {
+    auto it = map_.find(key);
+    if (it == map_.end()) return;
+    used_ -= it->second->data_size;
+    list_.erase(it->second);
+    map_.erase(it);
+}
+
+EvictResult MemoryCache::evict_lru() {
+    if (list_.empty()) return {EvictStatus::CacheEmpty};
+
+    // 从尾部向头部查找第一个非 pinned 项
+    auto it = list_.end();
+    while (it != list_.begin()) {
+        --it;
+        if (it->pinned) continue;
+
+        EvictResult result;
+        result.status      = EvictStatus::Success;
+        result.key         = it->key;
+        result.bytes_freed = it->data_size;
+
+        CacheItem evicted = std::move(*it);
+        map_.erase(evicted.key);
+        used_ -= evicted.data_size;
+        list_.erase(it);
+        result.item = std::move(evicted);
+        return result;
+    }
+    return {EvictStatus::AllPinned};
+}
+
+bool MemoryCache::contains(const std::string& key) const {
+    return map_.find(key) != map_.end();
+}
+
+bool MemoryCache::touch(const std::string& key) {
+    auto it = map_.find(key);
+    if (it == map_.end()) return false;
+    auto& item = *(it->second);
+    item.last_access = std::chrono::system_clock::now();
+    list_.splice(list_.begin(), list_, it->second);
+    return true;
+}
+
+bool MemoryCache::pin(const std::string& key) {
+    auto it = map_.find(key);
+    if (it == map_.end()) return false;
+    it->second->pinned = true;
+    return true;
+}
+
+bool MemoryCache::unpin(const std::string& key) {
+    auto it = map_.find(key);
+    if (it == map_.end()) return false;
+    it->second->pinned = false;
+    return true;
+}
+
+// ============================================================================
+// DiskCache
+// ============================================================================
+
+DiskCache::DiskCache(size_t capacity_bytes, std::filesystem::path directory)
+    : capacity_(capacity_bytes)
+    , dir_(std::move(directory)) {
+    // 创建缓存目录
+    std::error_code ec;
+    if (!std::filesystem::exists(dir_)) {
+        std::filesystem::create_directories(dir_, ec);
+        if (ec) {
+            CFW_LOG_ERROR("[DiskCache] Failed to create directory {}: {}",
+                          dir_.string(), ec.message());
+            return;
+        }
+    }
+
+    // 初始化：扫描已有文件
+    size_t total = 0;
+    for (auto& entry : std::filesystem::directory_iterator(dir_, ec)) {
+        if (ec) break;
+        if (!entry.is_regular_file()) continue;
+        std::string filename = entry.path().filename().string();
+        if (filename.size() < 6 || filename.substr(filename.size() - 6) != ".cache") continue;
+        // 文件名去掉 .cache 后缀即为 key 的哈希
+        std::string stored_key = filename.substr(0, filename.size() - 6);
+
+        auto fsize = entry.file_size(ec);
+        if (ec) { ec.clear(); continue; }
+        total += fsize;
+
+        CacheItem meta;
+        meta.key = stored_key;
+        meta.data_size = fsize;
+        meta.last_access = std::chrono::system_clock::now();
+        list_.push_back(stored_key);
+        map_[stored_key] = {std::move(meta), std::prev(list_.end())};
+    }
+    CFW_LOG_NOTICE("[DiskCache] Initialized {} ({} files, {} bytes used)",
+                   dir_.string(), map_.size(), total);
+}
+
+DiskCache::~DiskCache() = default;
+
+std::filesystem::path DiskCache::safe_path(const std::string& key) const {
+    // 将 key 中的非法字符替换为 '_'
+    std::string safe;
+    safe.reserve(key.size());
+    for (char c : key) {
+        if (c == '<' || c == '>' || c == ':' || c == '"' || c == '/' ||
+            c == '\\' || c == '|' || c == '?' || c == '*') {
+            safe += '_';
+        } else {
+            safe += c;
+        }
+    }
+    return dir_ / (safe + ".cache");
+}
+
+std::optional<CacheItem> DiskCache::read_file(const std::string& key) const {
+    auto path = safe_path(key);
+    std::error_code ec;
+    if (!std::filesystem::exists(path, ec)) return std::nullopt;
+
+    auto fsize = std::filesystem::file_size(path, ec);
+    if (ec || fsize == 0) return std::nullopt;
+
+    std::ifstream file(path, std::ios::binary);
+    if (!file) return std::nullopt;
+
+    CacheItem item;
+    item.key = key;
+    item.data.resize(fsize);
+    file.read(item.data.data(), static_cast<std::streamsize>(fsize));
+    item.data_size = fsize;
+    item.last_access = std::chrono::system_clock::now();
+    return item;
+}
+
+bool DiskCache::write_file(const CacheItem& item) const {
+    auto path = safe_path(item.key);
+    // 确保父目录存在（无符号链接）
+    auto parent = path.parent_path();
+    std::error_code ec;
+    if (std::filesystem::is_symlink(parent, ec)) {
+        CFW_LOG_ERROR("[DiskCache] Refusing to write to symlinked directory: {}",
+                      parent.string());
+        return false;
+    }
+    if (!std::filesystem::exists(parent, ec)) {
+        std::filesystem::create_directories(parent, ec);
+    }
+
+    std::ofstream file(path, std::ios::binary | std::ios::trunc);
+    if (!file) {
+        CFW_LOG_ERROR("[DiskCache] Failed to open {} for writing", path.string());
+        return false;
+    }
+    file.write(item.data.data(), static_cast<std::streamsize>(item.data.size()));
+    return file.good();
+}
+
+bool DiskCache::put(CacheItem item) {
+    std::lock_guard lock(mtx_);
+    auto key = item.key;
+    size_t item_size = item.data.size();
+
+    bool is_new_entry = false;
+    auto it = map_.find(key);
+    if (it != map_.end()) {
+        // ——— UPDATE 路径 ———
+        std::error_code ec;
+        std::filesystem::remove(safe_path(key), ec);
+        it->second.first = std::move(item);
+        it->second.first.data.clear();  // 磁盘不保留 data
+        // 提升到 LRU 头部
+        list_.splice(list_.begin(), list_, it->second.second);
+    } else {
+        // ——— INSERT 路径 ———
+        size_t current = calc_directory_size();
+        while (current + item_size > capacity_) {
+            if (!evict_one(key).ok()) break;
+            current = calc_directory_size();
+        }
+        if (current + item_size > capacity_) {
+            return false;
+        }
+
+        CacheItem meta;
+        meta.key = key;
+        meta.data_size = item_size;
+        meta.last_access = std::chrono::system_clock::now();
+        list_.push_front(key);
+        map_[key] = {std::move(meta), list_.begin()};
+        is_new_entry = true;
+    }
+
+    // 写入磁盘
+    if (!write_file(item)) {
+        // 回滚：仅清理 INSERT 路径创建的条目；UPDATE 路径的旧文件已删除无法恢复
+        if (is_new_entry) {
+            map_.erase(key);
+            if (!list_.empty() && list_.front() == key) list_.pop_front();
+        }
+        return false;
+    }
+
+    return true;
+}
+
+std::optional<CacheItem> DiskCache::get(const std::string& key) {
+    std::lock_guard lock(mtx_);
+    auto it = map_.find(key);
+    if (it == map_.end()) return std::nullopt;
+
+    auto data = read_file(key);
+    if (!data) {
+        // 文件丢失，清理映射
+        list_.erase(it->second.second);
+        map_.erase(it);
+        return std::nullopt;
+    }
+
+    // 提升到 LRU 头部
+    list_.splice(list_.begin(), list_, it->second.second);
+    it->second.first.last_access = std::chrono::system_clock::now();
+    return data;
+}
+
+void DiskCache::erase(const std::string& key) {
+    std::lock_guard lock(mtx_);
+    auto it = map_.find(key);
+    if (it == map_.end()) return;
+
+    std::error_code ec;
+    std::filesystem::remove(safe_path(key), ec);
+    list_.erase(it->second.second);
+    map_.erase(it);
+}
+
+bool DiskCache::contains(const std::string& key) const {
+    std::lock_guard lock(mtx_);
+    return map_.find(key) != map_.end();
+}
+
+bool DiskCache::touch(const std::string& key) {
+    std::lock_guard lock(mtx_);
+    auto it = map_.find(key);
+    if (it == map_.end()) return false;
+    it->second.first.last_access = std::chrono::system_clock::now();
+    list_.splice(list_.begin(), list_, it->second.second);
+    return true;
+}
+
+bool DiskCache::pin(const std::string& key) {
+    std::lock_guard lock(mtx_);
+    auto it = map_.find(key);
+    if (it == map_.end()) return false;
+    it->second.first.pinned = true;
+    return true;
+}
+
+bool DiskCache::unpin(const std::string& key) {
+    std::lock_guard lock(mtx_);
+    auto it = map_.find(key);
+    if (it == map_.end()) return false;
+    it->second.first.pinned = false;
+    return true;
+}
+
+size_t DiskCache::used_bytes() {
+    std::lock_guard lock(mtx_);
+    return calc_directory_size();
+}
+
+EvictResult DiskCache::evict_one(const std::string& skip_key) {
+    // 调用方（put）已持有 mtx_，此处不加锁
+    // 从尾部（最旧）向头部查找可淘汰项（跳过 skip_key 和 pinned 项）。
+    // 注意：在找到 victim 后立即 return，因此反向迭代器不会在被 erase 后继续使用。
+    for (auto rit = list_.rbegin(); rit != list_.rend(); ++rit) {
+        if (*rit == skip_key) continue;
+        auto map_it = map_.find(*rit);
+        if (map_it == map_.end()) continue;
+        if (map_it->second.first.pinned) continue;  // 不可淘汰
+
+        // 保存 forward iterator（比存 rit 更安全）
+        auto forward_it = map_it->second.second;
+        std::string victim_key = *rit;
+        size_t victim_bytes = map_it->second.first.data_size;
+
+        std::error_code ec;
+        std::filesystem::remove(safe_path(victim_key), ec);
+        list_.erase(forward_it);
+        map_.erase(map_it);
+
+        return {EvictStatus::Success, victim_key, victim_bytes, std::nullopt};
+    }
+    return {EvictStatus::AllPinned};
+}
+
+size_t DiskCache::calc_directory_size() const {
+    size_t total = 0;
+    std::error_code ec;
+    for (auto& entry : std::filesystem::recursive_directory_iterator(dir_, ec)) {
+        if (ec) break;
+        if (entry.is_regular_file()) {
+            total += entry.file_size();
+        }
+    }
+    return total;
+}
+
+// ============================================================================
+// CacheManager
+// ============================================================================
+
+CacheManager::CacheManager(size_t mem_capacity, size_t disk_capacity,
+                           std::filesystem::path disk_dir)
+    : mem_(mem_capacity) {
+    if (disk_capacity > 0) {
+        disk_.emplace(disk_capacity, std::move(disk_dir));
+    }
+}
+
+bool CacheManager::put(const std::string& key, const char* data, size_t size) {
+    // Phase 1: Lock — 尝试内存插入，失败则 evict 一个 victim
+    EvictResult evict_res;
+    {
+        std::lock_guard lock(mtx_);
+        if (mem_.put(key, data, size)) return true;
+        evict_res = mem_.evict_lru();
+    }
+
+    if (!evict_res.ok()) return false;  // 全部 pinned 或缓存空
+
+    // Phase 2: Unlocked — 将 victim 刷盘（DiskCache 用自己的内部锁）
+    auto& victim = evict_res.item;
+    if (disk_) {
+        CacheItem item;
+        item.key        = victim->key;
+        item.data       = std::move(victim->data);
+        item.data_size  = victim->data_size;
+        item.last_access = victim->last_access;
+
+        if (!disk_->put(std::move(item))) {
+            // 刷盘失败 → 回滚：尝试放回内存
+            std::lock_guard lock(mtx_);
+            if (!mem_.put(victim->key, victim->data.data(), victim->data.size())) {
+                if (evict_cb_) evict_cb_(victim->key, victim->data);
+            }
+            return false;
+        }
+    } else if (evict_cb_) {
+        evict_cb_(victim->key, victim->data);
+    }
+
+    // Phase 3: Lock — 插入新项
+    {
+        std::lock_guard lock(mtx_);
+        return mem_.put(key, data, size);
+    }
+}
+
+std::optional<CacheItem> CacheManager::get(const std::string& key) {
+    // Phase 1: Lock — 查内存
+    {
+        std::lock_guard lock(mtx_);
+        auto mem_result = mem_.get(key);
+        if (mem_result) return mem_result;
+    }
+
+    // Phase 2: Unlocked — 查磁盘（DiskCache 用自己的内部锁）
+    if (!disk_) return std::nullopt;
+    auto disk_result = disk_->get(key);
+    if (!disk_result) return std::nullopt;
+
+    // Phase 3: 提升到内存（可能需 evict + 刷盘腾空间）
+    auto& d = disk_result->data;
+    for (int attempt = 0; attempt < 2; ++attempt) {
+        EvictResult evict_res;
+        {
+            std::lock_guard lock(mtx_);
+            if (mem_.used_bytes() + d.size() <= mem_.capacity_bytes()) {
+                mem_.put(key, d.data(), d.size());
+                return disk_result;
+            }
+            evict_res = mem_.evict_lru();
+        }
+
+        if (!evict_res.ok()) break;  // 全部 pinned 或缓存空，放弃提升
+
+        // 将 victim 刷盘（DiskCache 锁独立，不阻塞 mem_）
+        auto& victim = evict_res.item;
+        if (disk_) {
+            CacheItem item;
+            item.key        = victim->key;
+            item.data       = std::move(victim->data);
+            item.data_size  = victim->data_size;
+            item.last_access = victim->last_access;
+            disk_->put(std::move(item));
+        } else if (evict_cb_) {
+            evict_cb_(victim->key, victim->data);
+        }
+    }
+
+    // 无法提升到内存（内存全 pinned）— 仍返回磁盘数据
+    return disk_result;
+}
+
+void CacheManager::erase(const std::string& key) {
+    std::lock_guard lock(mtx_);
+    mem_.erase(key);
+    if (disk_) disk_->erase(key);
+}
+
+bool CacheManager::contains(const std::string& key) {
+    std::lock_guard lock(mtx_);
+    if (mem_.contains(key)) return true;
+    if (disk_ && disk_->contains(key)) return true;
+    return false;
+}
+
+bool CacheManager::touch(const std::string& key) {
+    std::lock_guard lock(mtx_);
+    if (mem_.touch(key)) return true;
+    if (disk_ && disk_->touch(key)) return true;
+    return false;
+}
+
+bool CacheManager::pin(const std::string& key) {
+    std::lock_guard lock(mtx_);
+    bool found = false;
+    if (mem_.pin(key)) found = true;
+    if (disk_ && disk_->pin(key)) found = true;
+    return found;
+}
+
+bool CacheManager::unpin(const std::string& key) {
+    std::lock_guard lock(mtx_);
+    bool found = false;
+    if (mem_.unpin(key)) found = true;
+    if (disk_ && disk_->unpin(key)) found = true;
+    return found;
+}
+
+size_t CacheManager::memory_used() const {
+    std::lock_guard lock(mtx_);
+    return mem_.used_bytes();
+}
+
+size_t CacheManager::memory_capacity() const {
+    return mem_.capacity_bytes();
+}
+
+size_t CacheManager::disk_used() {
+    std::lock_guard lock(mtx_);
+    return disk_ ? disk_->used_bytes() : 0;
+}
+
+size_t CacheManager::disk_capacity() const {
+    return disk_ ? disk_->capacity_bytes() : 0;
+}
+
+void CacheManager::set_evict_callback(EvictCallback cb) {
+    std::lock_guard lock(mtx_);
+    evict_cb_ = std::move(cb);
+}
+
+}  // namespace Corona::Cache

--- a/modules/corona_resource/src/resource/cache/lru_cache.cpp
+++ b/modules/corona_resource/src/resource/cache/lru_cache.cpp
@@ -3,8 +3,10 @@
 #include <corona/kernel/core/i_logger.h>
 
 #include <algorithm>
+#include <cctype>
 #include <fstream>
 #include <regex>
+#include <stdexcept>
 #include <system_error>
 
 namespace Corona::Cache {
@@ -180,7 +182,27 @@ DiskCache::DiskCache(size_t capacity_bytes, std::filesystem::path directory)
 DiskCache::~DiskCache() = default;
 
 std::filesystem::path DiskCache::safe_path(const std::string& key) const {
-    // 将 key 中的非法字符替换为 '_'
+    // 1. 拒绝空 key
+    if (key.empty()) {
+        throw std::invalid_argument("DiskCache: key is empty");
+    }
+
+    // 2. 拒绝路径穿越（".." 组件）
+    if (key.find("..") != std::string::npos) {
+        throw std::invalid_argument("DiskCache: key contains '..': " + key);
+    }
+
+    // 3. 拒绝绝对路径（Unix '/' / Windows 盘符 'C:' / UNC '\\\\'）
+    if (key[0] == '/' || key[0] == '\\') {
+        throw std::invalid_argument("DiskCache: key is absolute path: " + key);
+    }
+    if (key.size() >= 3 && std::isalpha(static_cast<unsigned char>(key[0]))
+        && key[1] == ':' && (key[2] == '/' || key[2] == '\\')) {
+        throw std::invalid_argument("DiskCache: key is absolute path: " + key);
+    }
+
+    // —— 字符清洗 ————————————————————————————————
+    // 4. 将非法文件名字符替换为 '_'
     std::string safe;
     safe.reserve(key.size());
     for (char c : key) {
@@ -197,6 +219,10 @@ std::filesystem::path DiskCache::safe_path(const std::string& key) const {
 std::optional<CacheItem> DiskCache::read_file(const std::string& key) const {
     auto path = safe_path(key);
     std::error_code ec;
+
+    // 拒绝符号链接（防止通过 symlink 读取缓存目录外文件）
+    if (std::filesystem::is_symlink(path, ec)) return std::nullopt;
+
     if (!std::filesystem::exists(path, ec)) return std::nullopt;
 
     auto fsize = std::filesystem::file_size(path, ec);
@@ -226,6 +252,13 @@ bool DiskCache::write_file(const CacheItem& item) const {
     }
     if (!std::filesystem::exists(parent, ec)) {
         std::filesystem::create_directories(parent, ec);
+    }
+
+    // 确保文件路径本身非符号链接（防止通过 symlink 写入任意位置）
+    if (std::filesystem::is_symlink(path, ec)) {
+        CFW_LOG_ERROR("[DiskCache] Refusing to write to symlinked file: {}",
+                      path.string());
+        return false;
     }
 
     std::ofstream file(path, std::ios::binary | std::ios::trunc);

--- a/modules/corona_resource/src/resource/types/parse_common.h
+++ b/modules/corona_resource/src/resource/types/parse_common.h
@@ -680,8 +680,10 @@ inline SimplifyPhase1Result simplify_phase1(
     return result;
 }
 
-/// Phase 2: 将网格均匀拆分为多个子网格
-/// 每个子网格的顶点数都在 uint16 限制以下
+/// Phase 2: 将网格按空间位置拆分为多个子网格
+/// 先计算所有三角形的重心沿最长轴的位置，排序后再均分，
+/// 保证切口沿空间平面 → 最小化拆分边界处的缺口。
+/// 每个子网格的顶点数都在 uint16 限制以下。
 /// @param vertices 原始顶点数组
 /// @param indices 原始索引数组（三角形列表）
 /// @param unique_vertex_count 实际唯一顶点数（用于计算拆分数量）
@@ -709,6 +711,58 @@ inline std::vector<SingleMeshResult> split_mesh_uniformly(
     size_t num_splits = (unique_vertex_count + kSafeVertexLimit - 1) / kSafeVertexLimit;
     num_splits = std::max(num_splits, static_cast<size_t>(2));  // 至少拆分成 2 份
 
+    // ============================================================
+    // 按空间位置排序三角形，再均分
+    // 之前直接按三角形列表顺序切分，切口处三角形失去了相邻面 → 大面积缺口
+    // 现在先计算每个三角形的重心在最长沙轴上的投影，排序后切分，
+    // 切口沿空间平面 → 边界最小化
+    // ============================================================
+
+    // 1. 计算 AABB，找最长轴
+    std::array<float, 3> aabb_min = {FLT_MAX, FLT_MAX, FLT_MAX};
+    std::array<float, 3> aabb_max = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
+    for (size_t t = 0; t < triangle_count; ++t) {
+        for (int j = 0; j < 3; ++j) {
+            uint32_t vi = indices[t * 3 + j];
+            if (vi < vertices.size()) {
+                for (int k = 0; k < 3; ++k) {
+                    float p = vertices[vi].position[k];
+                    if (p < aabb_min[k]) aabb_min[k] = p;
+                    if (p > aabb_max[k]) aabb_max[k] = p;
+                }
+            }
+        }
+    }
+    float axis_x = aabb_max[0] - aabb_min[0];
+    float axis_y = aabb_max[1] - aabb_min[1];
+    float axis_z = aabb_max[2] - aabb_min[2];
+    int longest_axis = 0;
+    if (axis_y > axis_x) longest_axis = 1;
+    if (axis_z > axis_x && axis_z > axis_y) longest_axis = 2;
+
+    // 2. 计算每个三角形重心在最长沙轴上的投影，存入 (projection, original_index) 对
+    struct TriProjection {
+        float proj;
+        size_t tri_idx;
+    };
+    std::vector<TriProjection> tri_projections(triangle_count);
+    for (size_t t = 0; t < triangle_count; ++t) {
+        uint32_t i0 = indices[t * 3 + 0];
+        uint32_t i1 = indices[t * 3 + 1];
+        uint32_t i2 = indices[t * 3 + 2];
+        float centroid = 0.0f;
+        if (i0 < vertices.size()) centroid += vertices[i0].position[longest_axis];
+        if (i1 < vertices.size()) centroid += vertices[i1].position[longest_axis];
+        if (i2 < vertices.size()) centroid += vertices[i2].position[longest_axis];
+        centroid /= 3.0f;
+        tri_projections[t] = {centroid, t};
+    }
+
+    // 3. 沿最长轴排序
+    std::sort(tri_projections.begin(), tri_projections.end(),
+              [](const TriProjection& a, const TriProjection& b) { return a.proj < b.proj; });
+
+    // 4. 按排序后的顺序均分三角形
     size_t triangles_per_split = (triangle_count + num_splits - 1) / num_splits;
 
     // 执行拆分
@@ -718,11 +772,12 @@ inline std::vector<SingleMeshResult> split_mesh_uniformly(
 
         if (start_tri >= triangle_count) break;
 
-        // 收集这个分片的索引
+        // 收集这个分片的索引（按空间排序后的顺序）
         std::vector<std::uint32_t> split_indices;
         split_indices.reserve((end_tri - start_tri) * 3);
 
-        for (size_t tri = start_tri; tri < end_tri; ++tri) {
+        for (size_t s = start_tri; s < end_tri; ++s) {
+            size_t tri = tri_projections[s].tri_idx;
             split_indices.push_back(indices[tri * 3 + 0]);
             split_indices.push_back(indices[tri * 3 + 1]);
             split_indices.push_back(indices[tri * 3 + 2]);
@@ -743,7 +798,7 @@ inline std::vector<SingleMeshResult> split_mesh_uniformly(
             CFW_LOG_WARNING("[MeshOpt] Mesh '{}' split {}: {} unique vertices still exceeds limit, further splitting",
                             mesh_name, split_idx, unique_count);
 
-            // 递归拆分这个分片
+            // 收集这个分片的索引
             auto sub_splits = split_mesh_uniformly(vertices, split_indices, unique_count,
                                                    mesh_name + "_sub" + std::to_string(split_idx));
             results.insert(results.end(), sub_splits.begin(), sub_splits.end());
@@ -764,8 +819,9 @@ inline std::vector<SingleMeshResult> split_mesh_uniformly(
             sizeof(Vertex),
             remap.data());
 
-        CFW_LOG_TRACE("[MeshOpt] Mesh '{}' split {}: {} vertices, {} indices",
-                      mesh_name, split_idx, split_result.vertices.size(), split_result.indices.size());
+        CFW_LOG_TRACE("[MeshOpt] Mesh '{}' split {}: {} vertices, {} indices (spatial axis={})",
+                      mesh_name, split_idx, split_result.vertices.size(), split_result.indices.size(),
+                      longest_axis);
 
         results.push_back(std::move(split_result));
     }
@@ -1023,26 +1079,13 @@ inline std::vector<LODLevel> generate_lod_levels(
             &result_error);
 
         // 如果 meshopt_simplify 未能达到目标（实际 > 目标的 2 倍），
-        // 使用 meshopt_simplifySloppy 强制达到目标面数
-        // （不保拓扑，但能保证面数，适合物理碰撞等用途）
+        // 之前使用 meshopt_simplifySloppy 强制达到目标面数，
+        // 但 sloppy 不保拓扑，会产生裂缝/破洞/翻转三角形，导致渲染缺口。
+        // 现在改为：保持 simplify 的结果，宁可面数多一点也不牺牲拓扑正确性。
         if (simplified_count > target_index_count * 2) {
-
-            float sloppy_error = 0.0f;
-            size_t sloppy_count = meshopt_simplifySloppy(
-                simplified_indices.data(),
-                indices_u32.data(),
-                indices_u32.size(),
-                &vertices[0].position[0],
-                vertices.size(),
-                sizeof(Vertex),
-                target_index_count,
-                level_max_error,
-                &sloppy_error);
-
-            if (sloppy_count > 0 && sloppy_count < simplified_count) {
-                simplified_count = sloppy_count;
-                result_error = sloppy_error;
-            }
+            CFW_LOG_WARNING("[LOD] Mesh '{}' LOD {}: simplify could not reach target (got {} indices, target was {}). "
+                            "Sloppy fallback disabled to preserve topology. Keeping simplify result.",
+                            mesh_name, i + 1, simplified_count, target_index_count);
         }
 
         if (simplified_count == 0) {
@@ -1075,8 +1118,23 @@ inline std::vector<LODLevel> generate_lod_levels(
             sizeof(Vertex),
             remap.data());
 
+        // 移除退化三角形（meshopt_simplifySloppy 可能产生零面积/退化三角形，导致渲染缺口）
+        remove_degenerate_triangles(compact_vertices, remapped_indices,
+                                    1e-12f, mesh_name + "_lod" + std::to_string(i + 1));
+
+        // 重新计算法线：仅当几何真的被简化了才需要。
+        // 对于 split 子网格（有大面积切口边界），SimplifyLockBorder 可能导致
+        // 简化完全无法进行 → simplified_count == original_count → 几何未变。
+        // 此时若重算法线，边界处缺少相邻 split 的三角形贡献 → 法线偏斜 → 黑色缺口。
+        // 几何未变时保留 LOD0 原法线即可。
+        if (simplified_count < indices_u32.size()) {
+            generate_smooth_normals(compact_vertices, remapped_indices,
+                                    mesh_name + "_lod" + std::to_string(i + 1));
+        }
+
         // GPU 优化
-        optimize_mesh_for_gpu(compact_vertices, remapped_indices, mesh_name + "_lod" + std::to_string(i + 1));
+        optimize_mesh_for_gpu(compact_vertices, remapped_indices,
+                              mesh_name + "_lod" + std::to_string(i + 1));
 
         // 转换索引为 uint16
         std::vector<std::uint16_t> final_indices;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(CoronaEngine STATIC
         ${PROJECT_SOURCE_DIR}/include/corona/events/network_system_events.h
         ${PROJECT_SOURCE_DIR}/include/corona/events/optics_system_events.h
         ${PROJECT_SOURCE_DIR}/include/corona/events/script_system_events.h
+        ../include/corona/spatial/bvh.h
 )
 
 add_library(corona::engine ALIAS CoronaEngine)

--- a/src/systems/geometry/CMakeLists.txt
+++ b/src/systems/geometry/CMakeLists.txt
@@ -9,7 +9,9 @@ corona_add_system(geometry
         geometry_lod.cpp
         geometry_internal.h
         frustum.cpp
+        actor_cache.cpp
     DEPENDENCIES
         Horizon
         corona::resource::manager
+        nlohmann_json::nlohmann_json
 )

--- a/src/systems/geometry/actor_cache.cpp
+++ b/src/systems/geometry/actor_cache.cpp
@@ -1,0 +1,140 @@
+/// @file actor_cache.cpp
+/// @brief ActorCache 实现 + ActorSnapshot JSON 序列化
+
+#include <corona/systems/geometry/actor_cache.h>
+
+#include <corona/kernel/core/i_logger.h>
+
+#include <nlohmann/json.hpp>
+
+#include <sstream>
+
+namespace Corona::Cache {
+
+// ============================================================================
+// ActorSnapshot JSON 序列化
+// ============================================================================
+
+std::string ActorSnapshot::to_json() const {
+    nlohmann::json j;
+    j["model_path"]     = model_path.string();
+    j["pos_x"]          = position[0];
+    j["pos_y"]          = position[1];
+    j["pos_z"]          = position[2];
+    j["rot_x"]          = euler_rotation[0];
+    j["rot_y"]          = euler_rotation[1];
+    j["rot_z"]          = euler_rotation[2];
+    j["scl_x"]          = scale[0];
+    j["scl_y"]          = scale[1];
+    j["scl_z"]          = scale[2];
+    j["follow_camera"]  = follow_camera;
+    j["profile_count"]  = profile_count;
+    return j.dump();
+}
+
+std::optional<ActorSnapshot> ActorSnapshot::from_json(const std::string& json) {
+    try {
+        nlohmann::json j = nlohmann::json::parse(json);
+        ActorSnapshot snap;
+        snap.model_path       = j.value("model_path", "");
+        snap.position[0]      = j.value("pos_x", 0.0f);
+        snap.position[1]      = j.value("pos_y", 0.0f);
+        snap.position[2]      = j.value("pos_z", 0.0f);
+        snap.euler_rotation[0] = j.value("rot_x", 0.0f);
+        snap.euler_rotation[1] = j.value("rot_y", 0.0f);
+        snap.euler_rotation[2] = j.value("rot_z", 0.0f);
+        snap.scale[0]         = j.value("scl_x", 1.0f);
+        snap.scale[1]         = j.value("scl_y", 1.0f);
+        snap.scale[2]         = j.value("scl_z", 1.0f);
+        snap.follow_camera    = j.value("follow_camera", false);
+        snap.profile_count    = j.value("profile_count", 0);
+        return snap;
+    } catch (const nlohmann::json::exception& e) {
+        CFW_LOG_ERROR("[ActorCache] Failed to parse ActorSnapshot JSON: {}", e.what());
+        return std::nullopt;
+    }
+}
+
+// ============================================================================
+// ActorCache
+// ============================================================================
+
+ActorCache::ActorCache(size_t mem_capacity, size_t disk_capacity,
+                       std::filesystem::path disk_dir)
+    : cache_(mem_capacity, disk_capacity, std::move(disk_dir)) {}
+
+std::string ActorCache::make_key(std::uintptr_t handle) {
+    // 将指针地址格式化为 16 进制字符串
+    std::ostringstream oss;
+    oss << "actor_0x" << std::hex << handle;
+    return oss.str();
+}
+
+std::uintptr_t ActorCache::parse_key(const std::string& key) {
+    // 反向解析 make_key 产生的 key
+    // 格式: "actor_0x<hex>"
+    auto pos = key.find("0x");
+    if (pos == std::string::npos) return 0;
+    try {
+        return static_cast<std::uintptr_t>(std::stoull(key.substr(pos + 2), nullptr, 16));
+    } catch (...) {
+        return 0;
+    }
+}
+
+bool ActorCache::put(std::uintptr_t actor_handle, const ActorSnapshot& snapshot) {
+    std::string key = make_key(actor_handle);
+    std::string json = snapshot.to_json();
+    CFW_LOG_NOTICE("[ActorCache] Storing actor 0x{:x} ({} bytes)", actor_handle, json.size());
+    return cache_.put(key, json.data(), json.size());
+}
+
+std::optional<ActorSnapshot> ActorCache::get(std::uintptr_t actor_handle) {
+    std::string key = make_key(actor_handle);
+    auto item = cache_.get(key);
+    if (!item) return std::nullopt;
+
+    std::string json(item->data.data(), item->data.size());
+    auto snap = ActorSnapshot::from_json(json);
+    if (snap) {
+        CFW_LOG_NOTICE("[ActorCache] Cache hit for actor 0x{:x}", actor_handle);
+    }
+    return snap;
+}
+
+void ActorCache::remove(std::uintptr_t actor_handle) {
+    cache_.erase(make_key(actor_handle));
+}
+
+bool ActorCache::contains(std::uintptr_t actor_handle) {
+    return cache_.contains(make_key(actor_handle));
+}
+
+size_t ActorCache::memory_used() const {
+    return cache_.memory_used();
+}
+
+size_t ActorCache::memory_capacity() const {
+    return cache_.memory_capacity();
+}
+
+size_t ActorCache::disk_used() {
+    return cache_.disk_used();
+}
+
+size_t ActorCache::disk_capacity() const {
+    return cache_.disk_capacity();
+}
+
+void ActorCache::set_evict_callback(std::function<void(std::uintptr_t, const std::string&)> cb) {
+    cache_.set_evict_callback(
+        [cb = std::move(cb)](const std::string& key, const std::vector<char>& data) {
+            auto handle = parse_key(key);
+            if (handle != 0 && cb) {
+                std::string json(data.data(), data.size());
+                cb(handle, json);
+            }
+        });
+}
+
+}  // namespace Corona::Cache

--- a/src/systems/geometry/geometry_internal.h
+++ b/src/systems/geometry/geometry_internal.h
@@ -2,11 +2,14 @@
 
 #include <corona/spatial/bvh.h>
 #include <corona/spatial/octree.h>
+#include <corona/systems/geometry/actor_cache.h>
 #include <corona/systems/geometry/geometry_system.h>
 
 #include <algorithm>
 #include <cstdint>
+#include <filesystem>
 #include <future>
+#include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
@@ -119,6 +122,27 @@ struct GeometrySystem::Impl {
     // 共享占位纹理：所有无纹理 mesh 共用，生命周期与 Impl 一致
     // 使用 unique_ptr 避免 static 局部变量在 GPU device 析构后才析构
     std::unique_ptr<Horizon::HardwareImage> shared_placeholder_texture;
+
+    // ========================================
+    // LRU ActorCache（M3 生产化）
+    // ========================================
+    // 两级 LRU 缓存（内存 + 磁盘），存储被 evict 的 actor 快照
+    // 默认：64MB 内存 + 256MB 磁盘，目录可配置
+    static constexpr size_t kDefaultMemCacheBytes  = 64 * 1024 * 1024;
+    static constexpr size_t kDefaultDiskCacheBytes = 256 * 1024 * 1024;
+
+    std::unique_ptr<Corona::Cache::ActorCache> actor_cache;
+    std::filesystem::path                       actor_cache_dir;
+
+    /// 初始化 ActorCache（延迟到首次 evict/restore 时）
+    void ensure_actor_cache();
+
+    /// actor_handle → 最后一次快照时间（用于防抖）
+    std::unordered_map<Payload, std::chrono::steady_clock::time_point> last_snapshot_time;
+
+    /// evict 后待释放 GPU 的 actor 集合（延迟到下一帧 update() 头部处理，
+    /// 避免与 OpticsSystem 渲染线程产生 data race）
+    std::unordered_set<Payload> pending_gpu_releases;
 
     [[nodiscard]] static uint64_t make_lod_key(std::uintptr_t geometry_handle,
                                                uint32_t       mesh_index) {

--- a/src/systems/geometry/geometry_internal.h
+++ b/src/systems/geometry/geometry_internal.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <corona/spatial/bvh.h>
 #include <corona/spatial/octree.h>
 #include <corona/systems/geometry/geometry_system.h>
 
@@ -105,6 +106,10 @@ struct GeometrySystem::Impl {
     struct LODCacheEntry {
         std::vector<LODMeshBuffers> levels;
         std::uint64_t model_id = 0;  // 用于检测模型变更（比地址指针可靠，不受 slot 复用影响）
+
+        // 每个 LOD 级别一个 BVH（下标与 levels 一一对应）
+        // payload = 三角形下标（i/3），用于射线→三角形加速查询
+        std::vector<Spatial::BVH<uint32_t>> per_level_bvh;
     };
 
     MeshSimplificationConfig           simplification_cfg;

--- a/src/systems/geometry/geometry_system.cpp
+++ b/src/systems/geometry/geometry_system.cpp
@@ -510,11 +510,6 @@ void GeometrySystem::set_distance_config(std::uintptr_t scene, float unload_dist
     scene_state.cfg.preload_distance = preload_dist;
 }
 
-void GeometrySystem::set_invisible_frames_to_evict(std::uintptr_t scene, int frames) {
-    std::unique_lock lock(impl_->mtx);
-    impl_->get_or_create(scene).cfg.invisible_frames_to_evict = frames;
-}
-
 // ============================================================================
 // 私有事件处理
 // ============================================================================

--- a/src/systems/geometry/geometry_system.cpp
+++ b/src/systems/geometry/geometry_system.cpp
@@ -1,7 +1,10 @@
 #include <corona/events/engine_events.h>
 #include <corona/kernel/core/i_logger.h>
-#include <corona/shared_data_hub.h>
 #include <corona/kernel/utils/storage.h>
+#include <corona/resource/resource.h>
+#include <corona/resource/resource_manager.h>
+#include <corona/resource/types/scene.h>
+#include <corona/shared_data_hub.h>
 #include <corona/spatial/octree.h>
 #include <corona/systems/geometry/geometry_system.h>
 #include <corona/utils/path_utils.h>
@@ -10,6 +13,8 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <filesystem>
+#include <future>
 #include <limits>
 #include <mutex>
 #include <shared_mutex>
@@ -17,13 +22,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
-#include <filesystem>
-#include <future>
 #include <utility>
-
-#include <corona/resource/resource.h>
-#include <corona/resource/resource_manager.h>
-#include <corona/resource/types/scene.h>
 
 #include "geometry_internal.h"
 
@@ -436,6 +435,8 @@ void GeometrySystem::update() {
             scene_dev_write.min_world = root_aabb.min;
             scene_dev_write.max_world = root_aabb.max;
             scene_dev_write.center_world = root_aabb.center();
+            scene_dev_write.visible_actor_handles.assign(visible_actors.begin(),
+                                                         visible_actors.end());
         }
     }
 }
@@ -509,6 +510,11 @@ void GeometrySystem::set_distance_config(std::uintptr_t scene, float unload_dist
     scene_state.cfg.preload_distance = preload_dist;
 }
 
+void GeometrySystem::set_invisible_frames_to_evict(std::uintptr_t scene, int frames) {
+    std::unique_lock lock(impl_->mtx);
+    impl_->get_or_create(scene).cfg.invisible_frames_to_evict = frames;
+}
+
 // ============================================================================
 // 私有事件处理
 // ============================================================================
@@ -546,7 +552,7 @@ void GeometrySystem::on_unload_completed(const Events::ActorUnloadCompletedEvent
         if (actor_it != state_map.end() && actor_it->second == ActorLoadState::Unloading) {
             old_state = actor_it->second;
             actor_it->second = ActorLoadState::Unloaded;
-            impl_->offline_actors[event.actor] = false;
+            impl_->offline_actors[event.actor] = true;
         }
     }
     if (old_state == ActorLoadState::Unloading) {
@@ -1393,8 +1399,87 @@ const LODMeshBuffers* GeometrySystem::resolve_lod_buffers(
 }
 
 // ============================================================================
+// BVH 射线查询
+// ============================================================================
+
+std::vector<uint32_t> GeometrySystem::query_mesh_ray(
+    std::uintptr_t   geometry_handle,
+    uint32_t         mesh_index,
+    int              lod_level,
+    const ktm::fvec3& origin,
+    const ktm::fvec3& inv_dir) const
+{
+    std::shared_lock lock(impl_->lod_cache_mutex);
+    auto key = Impl::make_lod_key(geometry_handle, mesh_index);
+    auto it  = impl_->lod_cache.find(key);
+    if (it == impl_->lod_cache.end()) return {};
+    if (lod_level < 0 || static_cast<size_t>(lod_level) >= it->second.per_level_bvh.size())
+        return {};
+
+    std::vector<uint32_t> hits;
+    it->second.per_level_bvh[lod_level].query_ray(origin, inv_dir, hits);
+    return hits;
+}
+
+std::optional<Spatial::BVH<uint32_t>::Hit> GeometrySystem::query_mesh_closest_hit(
+    std::uintptr_t   geometry_handle,
+    uint32_t         mesh_index,
+    int              lod_level,
+    const ktm::fvec3& origin,
+    const ktm::fvec3& inv_dir,
+    float            t_max) const
+{
+    std::shared_lock lock(impl_->lod_cache_mutex);
+    auto key = Impl::make_lod_key(geometry_handle, mesh_index);
+    auto it  = impl_->lod_cache.find(key);
+    if (it == impl_->lod_cache.end()) return std::nullopt;
+    if (lod_level < 0 || static_cast<size_t>(lod_level) >= it->second.per_level_bvh.size())
+        return std::nullopt;
+
+    return it->second.per_level_bvh[lod_level].closest_hit(origin, inv_dir, t_max);
+}
+
+// ============================================================================
 // 动态减面内部管线
 // ============================================================================
+
+namespace {
+
+/// 从 CPU 端顶点+索引构建 BVH（payload = 三角形下标）
+/// @param vertices 顶点数组
+/// @param indices  uint16 索引数组（每 3 个一组构成三角形）
+/// @return 构建好的 BVH，无数据时返回空 BVH
+
+[[nodiscard]] Spatial::BVH<uint32_t> build_triangle_bvh(
+    const std::vector<Resource::Vertex>&    vertices,
+    const std::vector<std::uint16_t>&       indices)
+{
+    Spatial::BVH<uint32_t> bvh;
+    if (indices.size() < 3) return bvh;
+
+    std::vector<Spatial::BVH<uint32_t>::Entry> entries;
+    entries.reserve(indices.size() / 3);
+
+    for (size_t i = 0; i + 2 < indices.size(); i += 3) {
+        const auto& v0 = vertices[indices[i]];
+        const auto& v1 = vertices[indices[i + 1]];
+        const auto& v2 = vertices[indices[i + 2]];
+
+        Spatial::AABB aabb;
+        aabb.min.x = std::min({v0.position[0], v1.position[0], v2.position[0]});
+        aabb.min.y = std::min({v0.position[1], v1.position[1], v2.position[1]});
+        aabb.min.z = std::min({v0.position[2], v1.position[2], v2.position[2]});
+        aabb.max.x = std::max({v0.position[0], v1.position[0], v2.position[0]});
+        aabb.max.y = std::max({v0.position[1], v1.position[1], v2.position[1]});
+        aabb.max.z = std::max({v0.position[2], v1.position[2], v2.position[2]});
+        entries.push_back({static_cast<uint32_t>(i / 3), aabb});
+    }
+
+    bvh.build(entries);
+    return bvh;
+}
+
+}  // namespace
 
 void GeometrySystem::upload_lod_from_scene_data() {
     // 快照 simplification_cfg，与 set_simplification_config 同步
@@ -1461,39 +1546,28 @@ void GeometrySystem::upload_lod_from_scene_data() {
             lod0.ready            = true;
             entry.levels.push_back(std::move(lod0));
 
+            // 为 LOD 0 构建 BVH（三角形级空间索引）
+            entry.per_level_bvh.push_back(build_triangle_bvh(mesh.vertices, mesh.indices));
+
             // LOD 1..N：从导入时 meshoptimizer 生成的数据创建 GPU 缓冲
             for (size_t lod_idx = 0; lod_idx < mesh.lod_levels.size() && lod_idx < static_cast<size_t>(max_lod_levels - 1); ++lod_idx) {
                 auto& lod_data = mesh.lod_levels[lod_idx];
                 if (lod_data.vertices.empty() || lod_data.indices.empty()) continue;
 
                 LODMeshBuffers lod_buf;
-                // 转换为 uint32 索引（meshopt 输出 uint16，GPU 需要 uint32）
-                std::vector<uint32_t> indices32;
-                indices32.reserve(lod_data.indices.size());
-                for (auto idx : lod_data.indices) indices32.push_back(static_cast<uint32_t>(idx));
-
-                lod_buf.vertex_buffer = make_geometry_buffer(
-                    lod_data.vertices,
-                    Horizon::BufferUsageFlags::TransferDst | Horizon::BufferUsageFlags::Vertex,
-                    "geometry.lod_vertex");
-                lod_buf.index_buffer = make_geometry_buffer(
-                    indices32,
-                    Horizon::BufferUsageFlags::TransferDst | Horizon::BufferUsageFlags::Index,
-                    "geometry.lod_index");
-                lod_buf.vertex_storage = make_geometry_buffer(
-                    lod_data.vertices,
-                    Horizon::BufferUsageFlags::TransferSrc | Horizon::BufferUsageFlags::TransferDst |
-                        Horizon::BufferUsageFlags::Storage,
-                    "geometry.lod_vertex_storage");
-                lod_buf.index_storage = make_geometry_buffer(
-                    indices32,
-                    Horizon::BufferUsageFlags::TransferSrc | Horizon::BufferUsageFlags::TransferDst |
-                        Horizon::BufferUsageFlags::Storage,
-                    "geometry.lod_index_storage");
+                // LOD 索引保持 uint16（与 LOD0 一致），不转换为 uint32。
+                // 之前转为 uint32 导致 GPU 索引缓冲格式与 pipeline 预期不匹配→渲染缺口。
+                lod_buf.vertex_buffer    = make_geometry_buffer(lod_data.vertices, Horizon::BufferUsageFlags::TransferDst | Horizon::BufferUsageFlags::Vertex,     "geometry.lod_vertex");
+                lod_buf.index_buffer     = make_geometry_buffer(lod_data.indices,  Horizon::BufferUsageFlags::TransferDst | Horizon::BufferUsageFlags::Index,      "geometry.lod_index");
+                lod_buf.vertex_storage   = make_geometry_buffer(lod_data.vertices, Horizon::BufferUsageFlags::TransferSrc | Horizon::BufferUsageFlags::TransferDst | Horizon::BufferUsageFlags::Storage, "geometry.lod_vertex_storage");
+                lod_buf.index_storage    = make_geometry_buffer(lod_data.indices,  Horizon::BufferUsageFlags::TransferSrc | Horizon::BufferUsageFlags::TransferDst | Horizon::BufferUsageFlags::Storage, "geometry.lod_index_storage");
                 lod_buf.error            = lod_data.error;
                 lod_buf.screen_threshold = lod_data.screen_threshold;
                 lod_buf.ready            = true;
                 entry.levels.push_back(std::move(lod_buf));
+
+                // 为该 LOD 级别构建 BVH
+                entry.per_level_bvh.push_back(build_triangle_bvh(lod_data.vertices, lod_data.indices));
             }
 
             std::unique_lock lock(impl_->lod_cache_mutex);

--- a/src/systems/geometry/geometry_system.cpp
+++ b/src/systems/geometry/geometry_system.cpp
@@ -73,13 +73,13 @@ bool GeometrySystem::initialize(Kernel::ISystemContext* ctx) {
     CFW_LOG_NOTICE("GeometrySystem: Initializing (octree host)");
 
     if (ctx && ctx->event_bus()) {
-        auto id1 = ctx->event_bus()->subscribe<Events::ActorLoadCompletedEvent>(
-            [this](const Events::ActorLoadCompletedEvent& e) {
-                this->on_load_completed(e);
+        auto id1 = ctx->event_bus()->subscribe<Events::ActorLoadFinishedEvent>(
+            [this](const Events::ActorLoadFinishedEvent& e) {
+                this->on_load_finished(e);
             });
-        auto id2 = ctx->event_bus()->subscribe<Events::ActorUnloadCompletedEvent>(
-           [this](const Events::ActorUnloadCompletedEvent& e) {
-               this->on_unload_completed(e);
+        auto id2 = ctx->event_bus()->subscribe<Events::ActorUnloadFinishedEvent>(
+           [this](const Events::ActorUnloadFinishedEvent& e) {
+               this->on_unload_finished(e);
            });
         auto id3 = ctx->event_bus()->subscribe<Events::ActorLoadRequestedEvent>(
             [this](const Events::ActorLoadRequestedEvent& e) {
@@ -574,8 +574,7 @@ void GeometrySystem::set_cache_directory(std::filesystem::path dir) {
 // 私有事件处理
 // ============================================================================
 
-void GeometrySystem::on_load_completed(const Events::ActorLoadCompletedEvent& event) {
-    ActorLoadState old_state = ActorLoadState::Unloaded;
+void GeometrySystem::on_load_finished(const Events::ActorLoadFinishedEvent& event) {
     {
         std::unique_lock lock(impl_->mtx);
         auto scene_it = impl_->scenes.find(event.scene);
@@ -583,20 +582,18 @@ void GeometrySystem::on_load_completed(const Events::ActorLoadCompletedEvent& ev
             auto& state_map = scene_it->second.actor_load_states;
             auto actor_it = state_map.find(event.actor);
             if (actor_it != state_map.end() && actor_it->second == ActorLoadState::Loading) {
-                old_state = actor_it->second;
                 actor_it->second = ActorLoadState::Loaded;
                 impl_->offline_actors[event.actor] = false;
+                CFW_LOG_NOTICE("GeometrySystem: Actor {} (scene: {}) load finished",
+                               event.actor, event.scene);
             }
         }
-    } // 释放锁后发布事件
-    if (old_state == ActorLoadState::Loading) {
-        CFW_LOG_NOTICE("GeometrySystem: Actor {} (scene: {}) load completed", event.actor, event.scene);
-        impl_->ctx->event_bus()->publish(event);
     }
+    // 不再重新发布事件 — ActorLoadFinishedEvent 由 process_async_tasks()
+    // 在 GPU 资源重建完成后发布，外部系统直接订阅该事件即可。
 }
 
-void GeometrySystem::on_unload_completed(const Events::ActorUnloadCompletedEvent& event) {
-    ActorLoadState old_state = ActorLoadState::Loaded;
+void GeometrySystem::on_unload_finished(const Events::ActorUnloadFinishedEvent& event) {
     {
         std::unique_lock lock(impl_->mtx);
         auto scene_it = impl_->scenes.find(event.scene);
@@ -605,15 +602,14 @@ void GeometrySystem::on_unload_completed(const Events::ActorUnloadCompletedEvent
         auto& state_map = scene_it->second.actor_load_states;
         auto actor_it = state_map.find(event.actor);
         if (actor_it != state_map.end() && actor_it->second == ActorLoadState::Unloading) {
-            old_state = actor_it->second;
             actor_it->second = ActorLoadState::Unloaded;
             impl_->offline_actors[event.actor] = true;
+            CFW_LOG_NOTICE("GeometrySystem: Actor {} (scene: {}) unload finished",
+                           event.actor, event.scene);
         }
     }
-    if (old_state == ActorLoadState::Unloading) {
-        CFW_LOG_NOTICE("GeometrySystem: Actor {} (scene: {}) unload completed", event.actor, event.scene);
-        impl_->ctx->event_bus()->publish(event);
-    }
+    // 不再重新发布事件 — ActorUnloadFinishedEvent 由 process_async_tasks()
+    // 在 GPU 资源释放完成后发布，外部系统直接订阅该事件即可。
 }
 
 // ============================================================================
@@ -623,7 +619,7 @@ void GeometrySystem::on_unload_completed(const Events::ActorUnloadCompletedEvent
 // ============================================================================
 // release_actor_gpu_resources
 // 功能：释放指定 actor 占用的全部 GPU 资源（显存中的顶点/索引缓冲和纹理）
-// 调用时机：process_async_tasks() 中处理 ActorUnloadCompletedEvent 时
+// 调用时机：process_async_tasks() 中处理 ActorUnloadFinishedEvent 时
 // 注意：只清理 GPU 端资源，不删除 SharedDataHub 中的存储槽位
 // ============================================================================
 void GeometrySystem::release_actor_gpu_resources(std::uintptr_t actor) {
@@ -1164,11 +1160,11 @@ void GeometrySystem::process_async_tasks() {
 
         if (task.rid != Resource::IResource::INVALID_UID) {
             // 重建 GPU 资源（mesh_handles + 纹理），恢复 model_resource_handle
-            // 必须在发布 ActorLoadCompletedEvent 之前完成，
+            // 必须在发布 ActorLoadFinishedEvent 之前完成，
             // 以保证事件订阅者（渲染线程等）能读到有效的 GPU 缓冲
             rebuild_actor_gpu_resources(task.actor, task.rid);
 
-            impl_->ctx->event_bus()->publish(Events::ActorLoadCompletedEvent{task.scene_handle,task.actor});
+            impl_->ctx->event_bus()->publish(Events::ActorLoadFinishedEvent{task.scene_handle,task.actor});
             CFW_LOG_DEBUG("[SceneSystem] Actor {} loaded (resource: {})", task.actor, task.rid);
         }else {
             CFW_LOG_ERROR("[SceneSystem] Failed to load actor {}", task.actor);
@@ -1180,7 +1176,7 @@ void GeometrySystem::process_async_tasks() {
                     scene_it->second.actor_load_states[task.actor] = ActorLoadState::Unloaded;
                 }
             }
-            impl_->ctx->event_bus()->publish(Events::ActorUnloadCompletedEvent{task.scene_handle, task.actor});
+            impl_->ctx->event_bus()->publish(Events::ActorUnloadFinishedEvent{task.scene_handle, task.actor});
         }
     }
 
@@ -1197,7 +1193,7 @@ void GeometrySystem::process_async_tasks() {
                     scene_it->second.unload_retry_counts.erase(task.actor);
                 }
             }
-            impl_->ctx->event_bus()->publish(Events::ActorUnloadCompletedEvent{task.scene_handle, task.actor});
+            impl_->ctx->event_bus()->publish(Events::ActorUnloadFinishedEvent{task.scene_handle, task.actor});
             CFW_LOG_DEBUG("[SceneSystem] Actor {} unloaded", task.actor);
         } else {
             // 卸载失败，保存到列表中后续处理重试
@@ -1207,7 +1203,7 @@ void GeometrySystem::process_async_tasks() {
 
     //卸载失败重试
     if (!failed_unloads.empty()) {
-        std::vector<Events::ActorUnloadCompletedEvent> deferred_events;
+        std::vector<Events::ActorUnloadFinishedEvent> deferred_events;
         {
             std::unique_lock lock(impl_->mtx);
             for (const auto& task : failed_unloads) {
@@ -1292,7 +1288,7 @@ void GeometrySystem::on_load_requested(const Events::ActorLoadRequestedEvent& e)
         CFW_LOG_ERROR("[GeometrySystem] Invalid actor or empty model path: {}", e.actor);
         scene_state.actor_load_states[e.actor] = ActorLoadState::Unloaded;
         lock.unlock();
-        impl_->ctx->event_bus()->publish(Events::ActorUnloadCompletedEvent{e.scene,e.actor});
+        impl_->ctx->event_bus()->publish(Events::ActorUnloadFinishedEvent{e.scene,e.actor});
         return;
     }
 
@@ -1328,7 +1324,7 @@ void GeometrySystem::on_unload_requested(const Events::ActorUnloadRequestedEvent
     if (!actor_read.valid() || actor_read->model_path.empty()) {
         scene_state.actor_load_states[e.actor] = ActorLoadState::Unloaded;
         lock.unlock();
-        impl_->ctx->event_bus()->publish(Events::ActorUnloadCompletedEvent{e.scene, e.actor});
+        impl_->ctx->event_bus()->publish(Events::ActorUnloadFinishedEvent{e.scene, e.actor});
         return;
     }
 

--- a/src/systems/geometry/geometry_system.cpp
+++ b/src/systems/geometry/geometry_system.cpp
@@ -89,8 +89,17 @@ bool GeometrySystem::initialize(Kernel::ISystemContext* ctx) {
             [this](const Events::ActorUnloadRequestedEvent& e) {
                 this->on_unload_requested(e);
             });
+        // ---- M3 LRU：订阅 evict / restore 事件 ----
+        auto id5 = ctx->event_bus()->subscribe<Events::ActorEvictRequestedEvent>(
+            [this](const Events::ActorEvictRequestedEvent& e) {
+                this->on_evict_requested(e);
+            });
+        auto id6 = ctx->event_bus()->subscribe<Events::ActorRestoreRequestedEvent>(
+            [this](const Events::ActorRestoreRequestedEvent& e) {
+                this->on_restore_requested(e);
+            });
 
-        impl_->event_subscriptions = {id1,id2,id3,id4};
+        impl_->event_subscriptions = {id1, id2, id3, id4, id5, id6};
     }
 
     return true;
@@ -111,6 +120,21 @@ void GeometrySystem::update() {
     }
 
     process_async_tasks();
+
+    // ---- 延迟 GPU 释放（LRU evict 路径） ----
+    // on_evict_requested 将 actor 加入 pending_gpu_releases 集合，
+    // 延迟到此处（下一帧 update 头部）释放 GPU 资源，避免与
+    // OpticsSystem 渲染线程产生 data race。
+    if (!impl_->pending_gpu_releases.empty()) {
+        std::unordered_set<Impl::Payload> to_release;
+        {
+            std::unique_lock lock(impl_->mtx);
+            to_release.swap(impl_->pending_gpu_releases);
+        }
+        for (auto actor : to_release) {
+            release_actor_gpu_resources(actor);
+        }
+    }
 
     // ---- 动态减面管线 ----
     // 用 shared_lock 快照 simplification_cfg，与 set_simplification_config 的 unique_lock 互斥
@@ -261,6 +285,31 @@ void GeometrySystem::update() {
                                           std::chrono::steady_clock::now() - visible_query_begin)
                                           .count();
             visible_actors.insert(visible_for_camera.begin(),visible_for_camera.end());
+        }
+
+        // ---- M3 LRU 唤醒触发器 ----
+        // 遍历可见 actor，检查是否有被 evict 后 offline 的
+        std::vector<Events::ActorRestoreRequestedEvent> pending_restores;
+        {
+            std::shared_lock lock(impl_->mtx);
+            auto scene_it = impl_->scenes.find(scene_handle);
+            if (scene_it != impl_->scenes.end()) {
+                auto& scene_state = scene_it->second;
+                for (auto actor : visible_actors) {
+                    auto it = impl_->offline_actors.find(actor);
+                    if (it == impl_->offline_actors.end() || !it->second) continue;
+                    auto state_it = scene_state.actor_load_states.find(actor);
+                    if (state_it == scene_state.actor_load_states.end()) continue;
+                    if (state_it->second != ActorLoadState::Unloaded) continue;
+                    if (scene_state.loading_tasks.count(actor)) continue;
+                    if (scene_state.unloading_tasks.count(actor)) continue;
+                    pending_restores.push_back({scene_handle, actor});
+                }
+            }
+        }
+        for (const auto& evt : pending_restores) {
+            if (impl_->ctx && impl_->ctx->event_bus())
+                impl_->ctx->event_bus()->publish(evt);
         }
 
         std::vector<Events::ActorUnloadRequestedEvent> pending_unloads;
@@ -487,6 +536,10 @@ void GeometrySystem::shutdown() {
 
     impl_->scenes.clear();
     impl_->offline_actors.clear();
+    impl_->pending_gpu_releases.clear();
+
+    // 释放 LRU ActorCache（确保在 shutdown 时清理磁盘/内存）
+    impl_->actor_cache.reset();
 
     // 显式释放共享占位纹理，确保在 GPU device 仍存活时析构 HardwareImage
     impl_->shared_placeholder_texture.reset();
@@ -508,6 +561,13 @@ void GeometrySystem::set_distance_config(std::uintptr_t scene, float unload_dist
     scene_state.cfg.enable_distance_culling = enable;
     scene_state.cfg.unload_distance = unload_dist;
     scene_state.cfg.preload_distance = preload_dist;
+}
+
+void GeometrySystem::set_cache_directory(std::filesystem::path dir) {
+    impl_->actor_cache_dir = std::move(dir);
+    // 如果 ActorCache 已创建，下次 evict 时会沿用旧目录；
+    // 如果尚未创建，ensure_actor_cache() 将使用新目录。
+    CFW_LOG_NOTICE("[GeometrySystem] Cache directory set to {}", impl_->actor_cache_dir.string());
 }
 
 // ============================================================================
@@ -1284,6 +1344,159 @@ void GeometrySystem::on_unload_requested(const Events::ActorUnloadRequestedEvent
                   e.actor, Utils::path_to_utf8(actor_read->model_path));
     scene_state.unload_retry_counts[e.actor] = 0;
     scene_state.unloading_tasks[e.actor] = Resource::ResourceManager::get_instance().remove_cache_async(rid);
+}
+
+// ============================================================================
+// LRU ActorCache：ensure + evict/restore 事件处理
+// ============================================================================
+
+void GeometrySystem::Impl::ensure_actor_cache() {
+    if (actor_cache) return;
+    if (actor_cache_dir.empty()) {
+        // 默认目录：可执行文件同级的 cache/actors/
+        actor_cache_dir = std::filesystem::current_path() / "cache" / "actors";
+    }
+    actor_cache = std::make_unique<Corona::Cache::ActorCache>(
+        kDefaultMemCacheBytes,
+        kDefaultDiskCacheBytes,
+        actor_cache_dir);
+    CFW_LOG_NOTICE("[GeometrySystem] ActorCache initialized: mem={}MB disk={}MB dir={}",
+                   kDefaultMemCacheBytes / (1024 * 1024),
+                   kDefaultDiskCacheBytes / (1024 * 1024),
+                   actor_cache_dir.string());
+}
+
+void GeometrySystem::on_evict_requested(const Events::ActorEvictRequestedEvent& event) {
+    impl_->ensure_actor_cache();
+
+    auto& hub = SharedDataHub::instance();
+    const auto now = std::chrono::steady_clock::now();
+
+    // ---- 第 1 步：防抖检查（5 秒内不重复快照） ----
+    {
+        auto it = impl_->last_snapshot_time.find(event.actor);
+        if (it != impl_->last_snapshot_time.end()) {
+            auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - it->second);
+            if (elapsed.count() < 5) return;
+        }
+    }
+
+    // ---- 第 2 步：读取 actor 和 transform 数据 ----
+    auto actor_read = hub.actor_storage().try_acquire_read(event.actor);
+    if (!actor_read) return;
+
+    Corona::Cache::ActorSnapshot snap;
+    snap.model_path    = actor_read->model_path;
+    snap.follow_camera = actor_read->follow_camera;
+    snap.profile_count = static_cast<int>(actor_read->profile_handles.size());
+
+    // 读取第一个 profile 关联的 transform: profile → mechanics → geometry → transform
+    for (auto profile_handle : actor_read->profile_handles) {
+        auto profile = hub.profile_storage().try_acquire_read(profile_handle);
+        if (!profile) continue;
+
+        std::uintptr_t mech_handle = profile->mechanics_handle;
+        if (!mech_handle) continue;
+        auto mech = hub.mechanics_storage().try_acquire_read(mech_handle);
+        if (!mech) continue;
+
+        auto geom = hub.geometry_storage().try_acquire_read(mech->geometry_handle);
+        if (!geom || !geom->transform_handle) continue;
+
+        auto transform = hub.model_transform_storage().try_acquire_read(geom->transform_handle);
+        if (!transform) continue;
+
+        snap.position[0] = transform->position.x;
+        snap.position[1] = transform->position.y;
+        snap.position[2] = transform->position.z;
+        snap.euler_rotation[0] = transform->euler_rotation.x;
+        snap.euler_rotation[1] = transform->euler_rotation.y;
+        snap.euler_rotation[2] = transform->euler_rotation.z;
+        snap.scale[0] = transform->scale.x;
+        snap.scale[1] = transform->scale.y;
+        snap.scale[2] = transform->scale.z;
+        break;
+    }
+
+    // ---- 第 3 步：存入 ActorCache ----
+    if (!impl_->actor_cache->put(event.actor, snap)) {
+        CFW_LOG_ERROR("[GeometrySystem] Failed to cache actor {} snapshot", event.actor);
+    }
+
+    // ---- 第 4 步：标记 offline + 延迟 GPU 释放 ----
+    // 不在事件处理中直接调用 release_actor_gpu_resources，
+    // 避免与 OpticsSystem 渲染线程产生 data race。
+    // 改为加入 pending_gpu_releases 集合，在下一帧 update() 头部释放。
+    {
+        std::unique_lock lock(impl_->mtx);
+        impl_->offline_actors[event.actor] = true;
+        impl_->pending_gpu_releases.insert(event.actor);
+        auto scene_it = impl_->scenes.find(event.scene);
+        if (scene_it != impl_->scenes.end()) {
+            scene_it->second.actor_load_states[event.actor] = ActorLoadState::Unloaded;
+        }
+    }
+
+    impl_->last_snapshot_time[event.actor] = now;
+
+    CFW_LOG_NOTICE("[GeometrySystem] Actor {} evicted: cached snapshot ({} profiles, path={})",
+                   event.actor, snap.profile_count, snap.model_path.string());
+}
+
+void GeometrySystem::on_restore_requested(const Events::ActorRestoreRequestedEvent& event) {
+    impl_->ensure_actor_cache();
+
+    auto& hub = SharedDataHub::instance();
+
+    // ---- 第 1 步：从 ActorCache 获取快照 ----
+    auto snap = impl_->actor_cache->get(event.actor);
+    std::filesystem::path model_path;
+
+    if (snap) {
+        model_path = snap->model_path;
+        CFW_LOG_NOTICE("[GeometrySystem] Restoring actor {} from cache (path={})",
+                       event.actor, model_path.string());
+    } else {
+        // 缓存未命中：回退到从 ActorDevice 读取 model_path
+        auto actor_read = hub.actor_storage().try_acquire_read(event.actor);
+        if (!actor_read) {
+            CFW_LOG_ERROR("[GeometrySystem] Restore failed: actor {} not in storage", event.actor);
+            return;
+        }
+        model_path = actor_read->model_path;
+        CFW_LOG_NOTICE("[GeometrySystem] Restoring actor {} from disk (cache miss, path={})",
+                       event.actor, model_path.string());
+    }
+
+    if (model_path.empty()) {
+        CFW_LOG_ERROR("[GeometrySystem] Restore failed: actor {} has empty model path", event.actor);
+        return;
+    }
+
+    // ---- 第 2 步：检查是否已在加载/卸载中，然后启动异步导入 ----
+    {
+        std::unique_lock lock(impl_->mtx);
+        auto scene_it = impl_->scenes.find(event.scene);
+        if (scene_it == impl_->scenes.end()) return;
+        auto& scene_state = scene_it->second;
+
+        if (scene_state.loading_tasks.count(event.actor) ||
+            scene_state.unloading_tasks.count(event.actor)) {
+            CFW_LOG_NOTICE("[GeometrySystem] Restore: actor {} already in transition, skip",
+                           event.actor);
+            return;
+        }
+
+        // 如果该 actor 还在待释放 GPU 队列中，移除（不需要释放了）
+        impl_->pending_gpu_releases.erase(event.actor);
+
+        scene_state.actor_load_states[event.actor] = ActorLoadState::Loading;
+        scene_state.loading_tasks[event.actor] =
+            Resource::ResourceManager::get_instance().import_async(model_path);
+    }
+
+    CFW_LOG_NOTICE("[GeometrySystem] Restore started for actor {} ({})", event.actor,
+                   model_path.string());
 }
 
 // ============================================================================

--- a/src/systems/optics/optics_system.cpp
+++ b/src/systems/optics/optics_system.cpp
@@ -738,7 +738,10 @@ bool collect_actor_instances_for_visibility(
 
     bool has_instances = false;
     uint32_t object_id = 1;
-    for (auto actor_handle : scene.actor_handles) {
+    const auto& handles = scene.visible_actor_handles.empty()
+                              ? scene.actor_handles
+                              : scene.visible_actor_handles;
+    for (auto actor_handle : handles) {
         auto actor = actor_storage.try_acquire_read(actor_handle);
         if (!actor) {
             ++object_id;
@@ -2129,7 +2132,10 @@ void OpticsSystem::optics_pipeline(float frame_count, uint64_t frame_index) {
                     bool has_instances = false;
                     uint32_t recorded_draws = 0;
                     uint32_t object_id = 1;
-                    for (auto actor_handle : scene.actor_handles) {
+                    const auto& vis_handles = scene.visible_actor_handles.empty()
+                                                  ? scene.actor_handles
+                                                  : scene.visible_actor_handles;
+                    for (auto actor_handle : vis_handles) {
                         auto actor = actor_storage.try_acquire_read(actor_handle);
                         if (!actor) {
                             ++object_id;

--- a/src/systems/optics/vision/vision_geometry_adapter.cpp
+++ b/src/systems/optics/vision/vision_geometry_adapter.cpp
@@ -146,10 +146,22 @@ struct CpuMeshData {
     auto& geom_storage = hub.geometry_storage();
     auto& transform_storage = hub.model_transform_storage();
 
-    auto actor = actor_storage.try_acquire_read(actor_handle);
-    if (!actor) {
-        return false;
-    }
+    VisionBuildResult result;
+
+    // 用 cbegin/cend 显式取只读迭代器（共享读锁），避免非 const range-for 命中写迭代器。
+    for (auto scene_it = hub.scene_storage().cbegin(); scene_it != hub.scene_storage().cend(); ++scene_it) {
+        const auto& scene_dev = *scene_it;
+        if (!scene_dev.enabled) continue;
+
+        auto group = std::make_shared<::vision::ShapeGroup>();
+        bool group_has_instances = false;
+
+        const auto& handles = scene_dev.visible_actor_handles.empty()
+                                  ? scene_dev.actor_handles
+                                  : scene_dev.visible_actor_handles;
+        for (auto actor_handle : handles) {
+            auto actor = actor_storage.try_acquire_read(actor_handle);
+            if (!actor) continue;
 
     bool group_has_instances = false;
     for (auto profile_handle : actor->profile_handles) {

--- a/src/systems/script/python/corona_engine_api.cpp
+++ b/src/systems/script/python/corona_engine_api.cpp
@@ -8,6 +8,7 @@
 #include <corona/resource/types/scene.h>
 #include <corona/shared_data_hub.h>
 #include <corona/systems/script/corona_engine_api.h>
+#include <corona/systems/geometry/geometry_system.h>
 #include <corona/systems/optics/optics_system.h>
 #include <corona/utils/path_utils.h>
 
@@ -540,6 +541,47 @@ bool Corona::API::Scene::is_simulation_enabled() const {
         return accessor->simulation_enabled;
     }
     return false;
+}
+
+void Corona::API::Scene::set_visibility_config(int invisible_frames_to_evict) {
+    if (handle_ == 0) {
+        CFW_LOG_WARNING("[Scene::set_visibility_config] Invalid scene handle");
+        return;
+    }
+    auto* sys_mgr = Kernel::KernelContext::instance().system_manager();
+    if (!sys_mgr) {
+        CFW_LOG_ERROR("[Scene::set_visibility_config] SystemManager not available");
+        return;
+    }
+    auto geom_sys = std::dynamic_pointer_cast<Corona::Systems::GeometrySystem>(
+        sys_mgr->get_system("Geometry"));
+    if (!geom_sys) {
+        CFW_LOG_ERROR("[Scene::set_visibility_config] GeometrySystem not found");
+        return;
+    }
+    Corona::Systems::SceneVisibilityConfig cfg;
+    cfg.invisible_frames_to_evict = invisible_frames_to_evict;
+    cfg.collect_stats = true;
+    geom_sys->set_visibility_config(handle_, cfg);
+}
+
+void Corona::API::Scene::set_distance_config(float unload_dist, float preload_dist, bool enable) {
+    if (handle_ == 0) {
+        CFW_LOG_WARNING("[Scene::set_distance_config] Invalid scene handle");
+        return;
+    }
+    auto* sys_mgr = Kernel::KernelContext::instance().system_manager();
+    if (!sys_mgr) {
+        CFW_LOG_ERROR("[Scene::set_distance_config] SystemManager not available");
+        return;
+    }
+    auto geom_sys = std::dynamic_pointer_cast<Corona::Systems::GeometrySystem>(
+        sys_mgr->get_system("Geometry"));
+    if (!geom_sys) {
+        CFW_LOG_ERROR("[Scene::set_distance_config] GeometrySystem not found");
+        return;
+    }
+    geom_sys->set_distance_config(handle_, unload_dist, preload_dist, enable);
 }
 
 // ########################

--- a/src/systems/script/python/engine_bindings.cpp
+++ b/src/systems/script/python/engine_bindings.cpp
@@ -428,7 +428,17 @@ void BindAll(nanobind::module_& m) {
         .def("set_simulation_enabled", &Scene::set_simulation_enabled, nb::arg("enabled"),
              "Enable or disable physics simulation for this scene (does not affect rendering)")
         .def("is_simulation_enabled", &Scene::is_simulation_enabled,
-             "Return True if physics simulation is enabled for this scene");
+             "Return True if physics simulation is enabled for this scene")
+        // Scene streaming / visibility configuration
+        .def("set_visibility_config", &Scene::set_visibility_config,
+             nb::arg("invisible_frames_to_evict"),
+             "Set visibility eviction policy. invisible_frames_to_evict=0 disables eviction; "
+             ">0 triggers eviction after N consecutive invisible frames")
+        .def("set_distance_config", &Scene::set_distance_config,
+             nb::arg("unload_dist"), nb::arg("preload_dist"), nb::arg("enable") = true,
+             "Configure distance-based load/unload. unload_dist: distance beyond which invisible "
+             "actors are unloaded; preload_dist: distance within which actors are preloaded; "
+             "enable: toggle distance culling on/off");
 
     // ============================================================================
     // Scene I/O utilities


### PR DESCRIPTION
- BVH 数据结构 — 物体级包围体层次结构，加速射线/视锥相交测试                                             
  - 数据模型扩展 —                                                                                         
  ActorDevice.model_path、SceneVisibilityConfig（驱逐帧数/距离剔除参数）、SceneStats（加载/可见统计）      
  - Streaming 管线 — 四态状态机（Loaded/Loading/Unloading/Unloaded），资源释放遍历 4 条路径清空            
  mesh_handles + LOD cache，重载时重建全部 GPU 缓冲并回写                                                  
  - 渲染消费 — Native 和 Vision 管线均改为优先遍历 visible_actor_handles                                   
  - 网格拆分优化 — 沿最长轴空间排序后均分，减少拆分边界缺口                                                
  - Python 绑定 — Scene.set_visibility_config() / Scene.set_distance_config()，补齐 streaming激活入口                                                                    