### PR TITLE
feat(构建): 增加目标族 CMake 预设

### DIFF
--- a/.workspace/horizon.lock.json
+++ b/.workspace/horizon.lock.json
@@ -2,5 +2,5 @@
   "schema_version": 1,
   "url": "https://github.com/CoronaEngine/Horizon.git",
   "ref": "main",
-  "commit": "ac99daed3f890b5da7b2873826e5caaa1d7a6cd3"
+  "commit": "91ac2a81cc52d60b0228a87e724f13bd72fb8184"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ include(corona_cef)
 # Testing Support
 # ------------------------------------------------------------------------------
 include(CTest)
-if(BUILD_CORONA_TESTING AND NOT BUILD_TESTING)
+if(BUILD_CORONA_TESTING)
     enable_testing()
     set(CORONA_RESOURCE_BUILD_TESTS ON CACHE BOOL "Build CoronaResource tests" FORCE)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,39 +1,412 @@
 {
   "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 29,
+    "patch": 0
+  },
   "configurePresets": [
     {
-      "name": "relwithdebinfo",
-      "displayName": "RelWithDebInfo (default)",
+      "name": "core-debug",
+      "displayName": "Core - Debug",
       "generator": "Ninja Multi-Config",
-      "binaryDir": "${sourceDir}/build/conan/relwithdebinfo",
-      "cacheVariables": { "CORONA_DEV_CONFIGURATION": "RelWithDebInfo" }
+      "binaryDir": "${sourceDir}/build/conan/core/debug",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "Debug",
+        "CORONA_DEV_TARGET_FAMILY": "core"
+      }
+    },
+    {
+      "name": "core-relwithdebinfo",
+      "displayName": "Core - RelWithDebInfo",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/core/relwithdebinfo",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "RelWithDebInfo",
+        "CORONA_DEV_TARGET_FAMILY": "core"
+      }
+    },
+    {
+      "name": "core-release",
+      "displayName": "Core - Release",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/core/release",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "Release",
+        "CORONA_DEV_TARGET_FAMILY": "core"
+      }
+    },
+    {
+      "name": "core-minsizerel",
+      "displayName": "Core - MinSizeRel",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/core/minsizerel",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "MinSizeRel",
+        "CORONA_DEV_TARGET_FAMILY": "core"
+      }
+    },
+    {
+      "name": "examples-debug",
+      "displayName": "Examples - Debug",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/examples/debug",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "Debug",
+        "CORONA_DEV_TARGET_FAMILY": "examples"
+      }
+    },
+    {
+      "name": "examples-relwithdebinfo",
+      "displayName": "Examples - RelWithDebInfo",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/examples/relwithdebinfo",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "RelWithDebInfo",
+        "CORONA_DEV_TARGET_FAMILY": "examples"
+      }
+    },
+    {
+      "name": "examples-release",
+      "displayName": "Examples - Release",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/examples/release",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "Release",
+        "CORONA_DEV_TARGET_FAMILY": "examples"
+      }
+    },
+    {
+      "name": "examples-minsizerel",
+      "displayName": "Examples - MinSizeRel",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/examples/minsizerel",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "MinSizeRel",
+        "CORONA_DEV_TARGET_FAMILY": "examples"
+      }
+    },
+    {
+      "name": "tests-debug",
+      "displayName": "Tests - Debug",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/tests/debug",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "Debug",
+        "CORONA_DEV_TARGET_FAMILY": "tests"
+      }
+    },
+    {
+      "name": "tests-relwithdebinfo",
+      "displayName": "Tests - RelWithDebInfo",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/tests/relwithdebinfo",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "RelWithDebInfo",
+        "CORONA_DEV_TARGET_FAMILY": "tests"
+      }
+    },
+    {
+      "name": "tests-release",
+      "displayName": "Tests - Release",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/tests/release",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "Release",
+        "CORONA_DEV_TARGET_FAMILY": "tests"
+      }
+    },
+    {
+      "name": "tests-minsizerel",
+      "displayName": "Tests - MinSizeRel",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/tests/minsizerel",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "MinSizeRel",
+        "CORONA_DEV_TARGET_FAMILY": "tests"
+      }
+    },
+    {
+      "name": "vision-debug",
+      "displayName": "Vision - Debug",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/vision/debug",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "Debug",
+        "CORONA_DEV_TARGET_FAMILY": "vision"
+      }
+    },
+    {
+      "name": "vision-relwithdebinfo",
+      "displayName": "Vision - RelWithDebInfo",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/vision/relwithdebinfo",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "RelWithDebInfo",
+        "CORONA_DEV_TARGET_FAMILY": "vision"
+      }
+    },
+    {
+      "name": "vision-release",
+      "displayName": "Vision - Release",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/vision/release",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "Release",
+        "CORONA_DEV_TARGET_FAMILY": "vision"
+      }
+    },
+    {
+      "name": "vision-minsizerel",
+      "displayName": "Vision - MinSizeRel",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/vision/minsizerel",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "MinSizeRel",
+        "CORONA_DEV_TARGET_FAMILY": "vision"
+      }
+    },
+    {
+      "name": "vision-tests-debug",
+      "displayName": "Vision Tests - Debug",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/vision-tests/debug",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "Debug",
+        "CORONA_DEV_TARGET_FAMILY": "vision-tests"
+      }
+    },
+    {
+      "name": "vision-tests-relwithdebinfo",
+      "displayName": "Vision Tests - RelWithDebInfo",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/vision-tests/relwithdebinfo",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "RelWithDebInfo",
+        "CORONA_DEV_TARGET_FAMILY": "vision-tests"
+      }
+    },
+    {
+      "name": "vision-tests-release",
+      "displayName": "Vision Tests - Release",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/vision-tests/release",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "Release",
+        "CORONA_DEV_TARGET_FAMILY": "vision-tests"
+      }
+    },
+    {
+      "name": "vision-tests-minsizerel",
+      "displayName": "Vision Tests - MinSizeRel",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/vision-tests/minsizerel",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "MinSizeRel",
+        "CORONA_DEV_TARGET_FAMILY": "vision-tests"
+      }
+    },
+    {
+      "name": "vision-oidn-debug",
+      "displayName": "Vision OIDN - Debug",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/vision-oidn/debug",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "Debug",
+        "CORONA_DEV_TARGET_FAMILY": "vision-oidn"
+      }
+    },
+    {
+      "name": "vision-oidn-relwithdebinfo",
+      "displayName": "Vision OIDN - RelWithDebInfo",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/vision-oidn/relwithdebinfo",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "RelWithDebInfo",
+        "CORONA_DEV_TARGET_FAMILY": "vision-oidn"
+      }
+    },
+    {
+      "name": "vision-oidn-release",
+      "displayName": "Vision OIDN - Release",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/vision-oidn/release",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "Release",
+        "CORONA_DEV_TARGET_FAMILY": "vision-oidn"
+      }
+    },
+    {
+      "name": "vision-oidn-minsizerel",
+      "displayName": "Vision OIDN - MinSizeRel",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build/conan/vision-oidn/minsizerel",
+      "cacheVariables": {
+        "CORONA_DEV_CONFIGURATION": "MinSizeRel",
+        "CORONA_DEV_TARGET_FAMILY": "vision-oidn"
+      }
     },
     {
       "name": "debug",
-      "displayName": "Debug",
-      "generator": "Ninja Multi-Config",
-      "binaryDir": "${sourceDir}/build/conan/debug",
-      "cacheVariables": { "CORONA_DEV_CONFIGURATION": "Debug" }
+      "displayName": "Examples - Debug (legacy default)",
+      "inherits": "examples-debug"
+    },
+    {
+      "name": "relwithdebinfo",
+      "displayName": "Examples - RelWithDebInfo (legacy default)",
+      "inherits": "examples-relwithdebinfo"
     },
     {
       "name": "release",
-      "displayName": "Release",
-      "generator": "Ninja Multi-Config",
-      "binaryDir": "${sourceDir}/build/conan/release",
-      "cacheVariables": { "CORONA_DEV_CONFIGURATION": "Release" }
+      "displayName": "Examples - Release (legacy default)",
+      "inherits": "examples-release"
     },
     {
       "name": "minsizerel",
-      "displayName": "MinSizeRel",
-      "generator": "Ninja Multi-Config",
-      "binaryDir": "${sourceDir}/build/conan/minsizerel",
-      "cacheVariables": { "CORONA_DEV_CONFIGURATION": "MinSizeRel" }
+      "displayName": "Examples - MinSizeRel (legacy default)",
+      "inherits": "examples-minsizerel"
     }
   ],
   "buildPresets": [
-    { "name": "relwithdebinfo", "configurePreset": "relwithdebinfo", "configuration": "RelWithDebInfo" },
-    { "name": "debug", "configurePreset": "debug", "configuration": "Debug" },
-    { "name": "release", "configurePreset": "release", "configuration": "Release" },
-    { "name": "minsizerel", "configurePreset": "minsizerel", "configuration": "MinSizeRel" }
+    {
+      "name": "core-debug",
+      "configurePreset": "core-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "core-relwithdebinfo",
+      "configurePreset": "core-relwithdebinfo",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "core-release",
+      "configurePreset": "core-release",
+      "configuration": "Release"
+    },
+    {
+      "name": "core-minsizerel",
+      "configurePreset": "core-minsizerel",
+      "configuration": "MinSizeRel"
+    },
+    {
+      "name": "examples-debug",
+      "configurePreset": "examples-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "examples-relwithdebinfo",
+      "configurePreset": "examples-relwithdebinfo",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "examples-release",
+      "configurePreset": "examples-release",
+      "configuration": "Release"
+    },
+    {
+      "name": "examples-minsizerel",
+      "configurePreset": "examples-minsizerel",
+      "configuration": "MinSizeRel"
+    },
+    {
+      "name": "tests-debug",
+      "configurePreset": "tests-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "tests-relwithdebinfo",
+      "configurePreset": "tests-relwithdebinfo",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "tests-release",
+      "configurePreset": "tests-release",
+      "configuration": "Release"
+    },
+    {
+      "name": "tests-minsizerel",
+      "configurePreset": "tests-minsizerel",
+      "configuration": "MinSizeRel"
+    },
+    {
+      "name": "vision-debug",
+      "configurePreset": "vision-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "vision-relwithdebinfo",
+      "configurePreset": "vision-relwithdebinfo",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "vision-release",
+      "configurePreset": "vision-release",
+      "configuration": "Release"
+    },
+    {
+      "name": "vision-minsizerel",
+      "configurePreset": "vision-minsizerel",
+      "configuration": "MinSizeRel"
+    },
+    {
+      "name": "vision-tests-debug",
+      "configurePreset": "vision-tests-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "vision-tests-relwithdebinfo",
+      "configurePreset": "vision-tests-relwithdebinfo",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "vision-tests-release",
+      "configurePreset": "vision-tests-release",
+      "configuration": "Release"
+    },
+    {
+      "name": "vision-tests-minsizerel",
+      "configurePreset": "vision-tests-minsizerel",
+      "configuration": "MinSizeRel"
+    },
+    {
+      "name": "vision-oidn-debug",
+      "configurePreset": "vision-oidn-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "vision-oidn-relwithdebinfo",
+      "configurePreset": "vision-oidn-relwithdebinfo",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "vision-oidn-release",
+      "configurePreset": "vision-oidn-release",
+      "configuration": "Release"
+    },
+    {
+      "name": "vision-oidn-minsizerel",
+      "configurePreset": "vision-oidn-minsizerel",
+      "configuration": "MinSizeRel"
+    },
+    {
+      "name": "debug",
+      "configurePreset": "examples-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "relwithdebinfo",
+      "configurePreset": "examples-relwithdebinfo",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "release",
+      "configurePreset": "examples-release",
+      "configuration": "Release"
+    },
+    {
+      "name": "minsizerel",
+      "configurePreset": "examples-minsizerel",
+      "configuration": "MinSizeRel"
+    }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ uv / Python
 
 - Conan 是第三方库版本、二进制变体和 CMake package target 的唯一所有者；CMake 只查找并链接 Conan 生成的 target。
 - Horizon 是锁定提交的源码子项目，不是由 Conan 安装的 Horizon 包。父工程和 Horizon 共用一次 Conan 解析结果、profile 与 generators 目录。
-- 构建目录按配置隔离：<code>build/conan/debug</code>、<code>build/conan/release</code>、<code>build/conan/relwithdebinfo</code> 和 <code>build/conan/minsizerel</code>。不要把不同配置的生成文件混用。
+- 构建目录按“目标族 × 配置”隔离，例如 <code>build/conan/core/debug</code>、<code>build/conan/examples/debug</code> 和 <code>build/conan/vision-tests/relwithdebinfo</code>。不要把不同目标族或配置的生成文件混用。
 
 ## 环境要求
 
@@ -78,7 +78,7 @@ uv run --frozen python tools/dev.py build corona_engine --configuration Debug
 # 只构建已配置的指定 target
 uv run --frozen python tools/dev.py build-fast corona_engine --configuration Debug
 
-# 构建该配置中的全部默认 target
+# 构建 Examples 目标族中已配置的全部 target
 uv run --frozen python tools/dev.py build-fast all --configuration Debug
 ~~~
 
@@ -89,18 +89,29 @@ uv run --frozen python tools/dev.py build-fast all --configuration Debug
 | 命令 | 用途 |
 | --- | --- |
 | <code>uv run --frozen python tools/dev.py install --configuration Debug</code> | 只准备 Horizon 并运行 Conan install |
-| <code>uv run --frozen python tools/dev.py configure --configuration Debug</code> | Conan install 后执行 CMake configure |
+| <code>uv run --frozen python tools/dev.py configure --configuration Debug --target-family core</code> | Conan install 后配置指定目标族 |
 | <code>uv run --frozen python tools/dev.py build &lt;target&gt; --configuration Debug</code> | 完整安装、配置、构建流程 |
 | <code>uv run --frozen python tools/dev.py build-fast &lt;target&gt; --configuration Debug</code> | 只构建现有 CMake cache；不会自动配置 |
-| <code>uv run --frozen python tools/dev.py rebuild &lt;target&gt; --configuration Debug</code> | 删除该配置的构建目录后重新构建 |
+| <code>uv run --frozen python tools/dev.py rebuild &lt;target&gt; --configuration Debug</code> | 删除该目标族与配置的构建目录后重新构建 |
 | <code>uv run --frozen python tools/dev.py update --configuration Debug</code> | 在 Horizon 工作区干净时更新锁定源码和 Conan 解析结果 |
 | <code>uv run --frozen python tools/dev.py clean</code> | 删除本仓库的 build、install、out、dist；执行前确认不需要其中产物 |
 
-构建测试 target 时，名称中包含 <code>test</code> 的 target 会让脚本启用 Conan 的 <code>with_tests</code> 选项。例如：
+脚本会由 target 名称推断目标族，也可用 <code>--target-family</code> 显式指定。一个命令不能混合需要不同目标族的 target。
+
+| 目标族 | 示例 target | 主要内容 |
+| --- | --- | --- |
+| <code>core</code> | <code>CoronaEngine</code> | 引擎核心与资源系统，不构建示例、测试或 Vision |
+| <code>examples</code> | <code>corona_engine</code>、<code>all</code> | 默认示例与编辑器运行时部署；旧 preset 的兼容默认值 |
+| <code>tests</code> | <code>corona_resource_tests</code> | Corona/CoronaResource 的非 Vision 测试 |
+| <code>vision</code> | <code>vision-gui</code> | CUDA Vision 应用 |
+| <code>vision-tests</code> | <code>test-render_graph</code> | Vision 与依赖 CUDA 的 Corona Vision 测试 |
+| <code>vision-oidn</code> | <code>CP_OIDN_CUDA</code> | 启用 Open Image Denoise 的 Vision 构建 |
+
+例如，构建并运行非 Vision 的资源测试：
 
 ~~~powershell
 uv run --frozen python tools/dev.py build corona_resource_tests --configuration Debug
-ctest --test-dir build/conan/debug -C Debug --output-on-failure
+ctest --test-dir build/conan/tests/debug -C Debug --output-on-failure
 ~~~
 
 工作流脚本自身的快速回归测试不需要原生构建：
@@ -111,7 +122,9 @@ uv run --frozen python -m unittest tools/test_workflow.py
 
 ## 通过 CMake preset 构建
 
-脚本是推荐入口。若使用 CMake Tools，选择与所需配置对应的 <code>debug</code>、<code>release</code>、<code>relwithdebinfo</code> 或 <code>minsizerel</code> configure preset，再执行 Configure 和 Build。根 CMakeLists.txt 会调用开发 bootstrap，生成并加载对应配置的 Conan toolchain。
+脚本是推荐入口。若使用 CMake Tools，选择目标族 preset，例如 <code>core-debug</code>、<code>examples-debug</code>、<code>tests-debug</code>、<code>vision-debug</code>、<code>vision-tests-debug</code> 或 <code>vision-oidn-debug</code>，再执行 Configure 和 Build。根 CMakeLists.txt 会调用开发 bootstrap，生成并加载对应目标族和配置的 Conan toolchain。
+
+旧的 <code>debug</code>、<code>release</code>、<code>relwithdebinfo</code> 和 <code>minsizerel</code> preset 保留为 <code>examples-*</code> 的兼容别名。新开发应直接选择带目标族前缀的 preset。
 
 不要把 [.workspace/Horizon/README.md](.workspace/Horizon/README.md) 中的独立 Horizon preset 或工具命令直接套用于父工程：它们用于单独构建 Horizon，目录结构和 target family 与 CoronaEngine 不同。父工程只应使用根目录的 preset 和 tools/dev.py。
 
@@ -139,7 +152,7 @@ uv run --frozen python -m unittest tools/test_workflow.py
 - target 名称不兼容时，在 [misc/cmake/corona_third_party.cmake](misc/cmake/corona_third_party.cmake) 添加兼容别名或明确的 target 校验；只有 Horizon 使用时，通常应由 Horizon 的 CMake 模块完成查找。
 - 不要在 CMake 中重新引入 FetchContent、ExternalProject、file(DOWNLOAD) 或另一套包管理器来下载同一第三方库。
 
-根 Conan recipe 的主要 feature option 包括 <code>with_editor</code>、<code>with_examples</code>、<code>with_tests</code>、<code>with_vision</code>、<code>with_oidn</code> 与 <code>with_cef</code>。它们会生成相应的 CMake cache 变量。当前 tools/dev.py 会从 target 名称推断 tests、Vision 与 OIDN；需要新增独立 feature 时，应同步调整 Conan option、脚本映射和 Horizon 子项目开关，而不是只手改 CMake cache。
+根 Conan recipe 的主要 feature option 包括 <code>with_editor</code>、<code>with_examples</code>、<code>with_tests</code>、<code>with_vision</code>、<code>with_vision_tests</code>、<code>with_oidn</code> 与 <code>with_cef</code>。它们会生成相应的 CMake cache 变量。tools/dev.py 的目标族是这些 option 的唯一开发者入口；需要新增独立 feature 时，应同步调整 Conan option、目标族映射、preset、bootstrap 和 Horizon 子项目开关，而不是只手改 CMake cache。
 
 ### CUDA 与 Vision
 
@@ -177,7 +190,7 @@ echo $env:CUDA_PATH
 不要手工删除 generators 目录的一部分。重新运行：
 
 ~~~powershell
-uv run --frozen python tools/dev.py configure --configuration Debug
+uv run --frozen python tools/dev.py configure --configuration Debug --target-family examples
 ~~~
 
 若 cache 指向其他源码目录或配置目录，使用 <code>rebuild</code> 重新创建该配置的构建目录。

--- a/README.md
+++ b/README.md
@@ -1,0 +1,206 @@
+# CoronaEngine
+
+CoronaEngine 是一个以 CMake、Conan 2 和 C++20 构建的 Windows x64 引擎工程。它在同一构建图中集成锁定版本的 [Horizon](.workspace/Horizon)，并可选构建 CEF 编辑器、示例、资源系统和 CUDA 驱动的 Vision 功能。
+
+本文档面向首次在本仓库构建的开发者。所有命令均在仓库根目录执行。
+
+## 构建模型
+
+~~~text
+uv / Python
+    └─ tools/dev.py
+        ├─ 校验或准备 .workspace/Horizon
+        ├─ Conan install（一个依赖图、一个 MSVC profile）
+        ├─ 生成 Conan toolchain 与开发环境
+        └─ CMake configure / build
+             └─ add_subdirectory(.workspace/Horizon)
+~~~
+
+- Conan 是第三方库版本、二进制变体和 CMake package target 的唯一所有者；CMake 只查找并链接 Conan 生成的 target。
+- Horizon 是锁定提交的源码子项目，不是由 Conan 安装的 Horizon 包。父工程和 Horizon 共用一次 Conan 解析结果、profile 与 generators 目录。
+- 构建目录按配置隔离：<code>build/conan/debug</code>、<code>build/conan/release</code>、<code>build/conan/relwithdebinfo</code> 和 <code>build/conan/minsizerel</code>。不要把不同配置的生成文件混用。
+
+## 环境要求
+
+当前工作流仅支持 **Windows x64**。
+
+| 工具 | 要求 |
+| --- | --- |
+| Git | 克隆源码及管理锁定的 Horizon 工作区 |
+| [uv](https://docs.astral.sh/uv/) | 管理 Python 环境和 Conan；无需单独安装 Python 或 Conan |
+| CMake | 3.29 或更高版本 |
+| Ninja | 必须在 PATH 中；工程使用 Ninja Multi-Config |
+| Visual Studio 或 Build Tools | 安装“使用 C++ 的桌面开发”、MSVC x64/x86 工具集与 Windows SDK |
+| CUDA Toolkit | 仅 Vision / Ocarina / Vision Hotfix 需要；安装后应存在 CUDA_PATH |
+
+先在新的 PowerShell 中确认基础工具可用：
+
+~~~powershell
+git --version
+uv --version
+cmake --version
+ninja --version
+~~~
+
+首次进入仓库后同步开发环境：
+
+~~~powershell
+uv sync --frozen
+~~~
+
+项目要求 Python 3.11 及以上；如果本机没有合适版本，uv 会按自身配置处理 Python 安装。首次同步、Conan 安装或编译依赖耗时较长属于正常情况。
+
+### VS Code / CMake Tools
+
+使用 VS Code 的 CMake Tools 时，在设置中将 <code>CMake: Use VS Developer Environment</code> 设为 <code>always</code>，或加入用户设置：
+
+~~~json
+"cmake.useVsDeveloperEnvironment": "always"
+~~~
+
+否则 CMake Tools 单独启动的进程可能没有 MSVC 和 Windows SDK 环境，常见表现为 <code>fatal error C1083</code> 或找不到 <code>stddef.h</code> 等标准头文件。
+
+## 快速开始
+
+~~~powershell
+# 查看分支、Horizon 锁定提交、Conan 与 CMake preset
+uv run --frozen python tools/dev.py status
+
+# 完整准备并构建默认引擎示例（Debug）
+uv run --frozen python tools/dev.py build corona_engine --configuration Debug
+~~~
+
+<code>build</code> 会依次准备 Horizon、运行 Conan、配置 CMake，再构建指定 target。默认的 <code>corona_engine</code> 是 <code>examples/engine</code> 中的可执行示例；构建后请从 CMake 报告的 target 输出目录运行它，以保留生成的运行时文件。
+
+已成功配置过同一配置目录后，可使用较快的增量构建：
+
+~~~powershell
+# 只构建已配置的指定 target
+uv run --frozen python tools/dev.py build-fast corona_engine --configuration Debug
+
+# 构建该配置中的全部默认 target
+uv run --frozen python tools/dev.py build-fast all --configuration Debug
+~~~
+
+配置名称必须使用 <code>Debug</code>、<code>Release</code>、<code>RelWithDebInfo</code> 或 <code>MinSizeRel</code>。脚本参数使用此大小写；对应的 CMake preset 名称为小写。
+
+## 日常命令
+
+| 命令 | 用途 |
+| --- | --- |
+| <code>uv run --frozen python tools/dev.py install --configuration Debug</code> | 只准备 Horizon 并运行 Conan install |
+| <code>uv run --frozen python tools/dev.py configure --configuration Debug</code> | Conan install 后执行 CMake configure |
+| <code>uv run --frozen python tools/dev.py build &lt;target&gt; --configuration Debug</code> | 完整安装、配置、构建流程 |
+| <code>uv run --frozen python tools/dev.py build-fast &lt;target&gt; --configuration Debug</code> | 只构建现有 CMake cache；不会自动配置 |
+| <code>uv run --frozen python tools/dev.py rebuild &lt;target&gt; --configuration Debug</code> | 删除该配置的构建目录后重新构建 |
+| <code>uv run --frozen python tools/dev.py update --configuration Debug</code> | 在 Horizon 工作区干净时更新锁定源码和 Conan 解析结果 |
+| <code>uv run --frozen python tools/dev.py clean</code> | 删除本仓库的 build、install、out、dist；执行前确认不需要其中产物 |
+
+构建测试 target 时，名称中包含 <code>test</code> 的 target 会让脚本启用 Conan 的 <code>with_tests</code> 选项。例如：
+
+~~~powershell
+uv run --frozen python tools/dev.py build corona_resource_tests --configuration Debug
+ctest --test-dir build/conan/debug -C Debug --output-on-failure
+~~~
+
+工作流脚本自身的快速回归测试不需要原生构建：
+
+~~~powershell
+uv run --frozen python -m unittest tools/test_workflow.py
+~~~
+
+## 通过 CMake preset 构建
+
+脚本是推荐入口。若使用 CMake Tools，选择与所需配置对应的 <code>debug</code>、<code>release</code>、<code>relwithdebinfo</code> 或 <code>minsizerel</code> configure preset，再执行 Configure 和 Build。根 CMakeLists.txt 会调用开发 bootstrap，生成并加载对应配置的 Conan toolchain。
+
+不要把 [.workspace/Horizon/README.md](.workspace/Horizon/README.md) 中的独立 Horizon preset 或工具命令直接套用于父工程：它们用于单独构建 Horizon，目录结构和 target family 与 CoronaEngine 不同。父工程只应使用根目录的 preset 和 tools/dev.py。
+
+## 功能与依赖注意事项
+
+### Horizon 工作区
+
+<code>.workspace/horizon.lock.json</code> 固定 Horizon 的仓库地址、分支和具体提交。开发脚本会：
+
+1. 在 <code>.workspace/Horizon</code> 不存在时克隆并检出锁定提交；
+2. 校验远程地址和当前 HEAD 必须与锁文件一致；
+3. 不会为了匹配锁文件而覆盖 Horizon 的本地修改。
+
+因此，不要手动切换该目录的分支或提交后再运行父工程构建。需要升级 Horizon 时使用 <code>tools/dev.py update</code>；若 Horizon 工作区有未提交修改，更新会被拒绝。提交锁文件变更前，应先确认 CoronaEngine 的 Conan 图仍能统一所有包的版本、ABI、MSVC runtime 和 CUDA 选项。
+
+父工程固定启用 Horizon tools，关闭其 examples、tests 和 benchmarks；Horizon 的 Ocarina 与 Vision Hotfix 随 <code>CORONA_BUILD_VISION</code> 开关启用。不要在 CoronaEngine 的构建流程中对 <code>.workspace/Horizon</code> 再运行一次 <code>conan install</code>，否则会产生不一致的依赖图和 generators 目录。
+
+### 第三方库
+
+新增或升级依赖时遵循以下边界：
+
+- CoronaEngine 自己使用的包：在根 [conanfile.py](conanfile.py) 声明版本和 option，在 CMake 中查找并链接导出的 target。
+- Horizon 新增的、且会被 CoronaEngine 当前启用功能使用的包：除了 Horizon 自己的 conanfile.py 外，也要在根 conanfile.py 声明。因为集成构建只解析父工程的 Conan 图。
+- 仅由当前被关闭的 Horizon target family 使用的包，不应无条件带入父工程依赖图。
+- target 名称不兼容时，在 [misc/cmake/corona_third_party.cmake](misc/cmake/corona_third_party.cmake) 添加兼容别名或明确的 target 校验；只有 Horizon 使用时，通常应由 Horizon 的 CMake 模块完成查找。
+- 不要在 CMake 中重新引入 FetchContent、ExternalProject、file(DOWNLOAD) 或另一套包管理器来下载同一第三方库。
+
+根 Conan recipe 的主要 feature option 包括 <code>with_editor</code>、<code>with_examples</code>、<code>with_tests</code>、<code>with_vision</code>、<code>with_oidn</code> 与 <code>with_cef</code>。它们会生成相应的 CMake cache 变量。当前 tools/dev.py 会从 target 名称推断 tests、Vision 与 OIDN；需要新增独立 feature 时，应同步调整 Conan option、脚本映射和 Horizon 子项目开关，而不是只手改 CMake cache。
+
+### CUDA 与 Vision
+
+<code>CORONA_BUILD_VISION</code> 默认根据 <code>CUDA_PATH</code> 或 CMake 的 CUDA Toolkit 检测结果启用。显式开启 Vision 但未检测到 CUDA 时，CMake 会警告并关闭 Vision，避免在深层 Vision/Horizon 子目录失败。
+
+若需要 Ocarina 或 Vision Hotfix，请先确认：
+
+~~~powershell
+echo $env:CUDA_PATH
+~~~
+
+能输出有效 CUDA Toolkit 目录，再配置和构建。CUDA、Conan 的 Vision option 与 Horizon 的 Ocarina option 必须保持一致。
+
+### 运行时文件
+
+构建成功不代表可以只复制一个 .exe 到其他目录运行。示例 target 的构建后步骤会部署所需内容，包括：
+
+- 嵌入式 Python 运行时和相关 DLL；
+- TBB、Assimp 等运行时库；
+- FFmpeg 的带 ABI 版本 DLL；
+- 启用 CEF 时的 libcef、子进程、资源包和 locales；
+- 启用编辑器时的 CabbageEditor 前端及资源；
+- 需要时的 Horizon/Helicon 运行时依赖和项目 assets。
+
+请从 target 输出目录运行，或使用正式安装/打包流程。移动程序时必须连同构建后部署的内容一起移动。
+
+## 常见问题
+
+### CMake 找不到标准头文件
+
+确认 VS / Build Tools 安装了 C++ 工作负载和 Windows SDK。若在 VS Code 中发生，设置 <code>cmake.useVsDeveloperEnvironment</code> 为 <code>always</code>，重启 VS Code 后重新 Configure。
+
+### 找不到 Conan toolchain 或 dev_build_environment.cmake
+
+不要手工删除 generators 目录的一部分。重新运行：
+
+~~~powershell
+uv run --frozen python tools/dev.py configure --configuration Debug
+~~~
+
+若 cache 指向其他源码目录或配置目录，使用 <code>rebuild</code> 重新创建该配置的构建目录。
+
+### Horizon 锁定提交不匹配或工作区有修改
+
+先检查：
+
+~~~powershell
+uv run --frozen python tools/dev.py status
+git -C .workspace/Horizon status --short
+~~~
+
+保留、提交或自行处理本地 Horizon 改动，再决定是否执行 <code>tools/dev.py update</code>。不要通过删除锁文件或强制重置工作区来绕过检查。
+
+### 首次构建很慢
+
+首次需要下载或构建 Conan 二进制包，并生成 shader、CEF/编辑器和运行时文件。后续在相同配置目录下优先使用 <code>build-fast</code>。
+
+## 相关入口
+
+- 根构建入口：[CMakeLists.txt](CMakeLists.txt)
+- 开发工作流：[tools/dev.py](tools/dev.py)
+- Conan 依赖和 feature option：[conanfile.py](conanfile.py)
+- Horizon 锁文件：[.workspace/horizon.lock.json](.workspace/horizon.lock.json)
+- Horizon 独立构建指南：[.workspace/Horizon/README.md](.workspace/Horizon/README.md)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,7 @@
 import os
 
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 
 required_conan_version = ">=2.28"
@@ -10,6 +11,14 @@ class CoronaEngineConan(ConanFile):
     name = "coronaengine"
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
+    _target_families = (
+        "core",
+        "examples",
+        "tests",
+        "vision",
+        "vision-tests",
+        "vision-oidn",
+    )
 
     options = {
         "shared": [True, False],
@@ -17,6 +26,7 @@ class CoronaEngineConan(ConanFile):
         "with_examples": [True, False],
         "with_tests": [True, False],
         "with_vision": [True, False],
+        "with_vision_tests": [True, False],
         "with_oidn": [True, False],
         "with_cef": [True, False],
     }
@@ -27,6 +37,7 @@ class CoronaEngineConan(ConanFile):
         "with_examples": True,
         "with_tests": False,
         "with_vision": True,
+        "with_vision_tests": False,
         "with_oidn": False,
         "with_cef": True,
         "sdl/*:shared": False,
@@ -42,7 +53,13 @@ class CoronaEngineConan(ConanFile):
 
     def layout(self):
         configuration = str(self.settings.build_type).lower()
-        cmake_layout(self, build_folder=f"build/conan/{configuration}")
+        target_family = self.conf.get("user.corona:target_family", default="examples")
+        if target_family not in self._target_families:
+            raise ConanInvalidConfiguration(
+                f"Unsupported user.corona:target_family='{target_family}'. "
+                f"Expected one of: {', '.join(self._target_families)}"
+            )
+        cmake_layout(self, build_folder=f"build/conan/{target_family}/{configuration}")
 
     def set_version(self):
         self.version = os.environ.get("CORONAENGINE_CONAN_VERSION", "0.5.0")
@@ -89,12 +106,17 @@ class CoronaEngineConan(ConanFile):
         deps.generate()
 
         toolchain = CMakeToolchain(self)
+        # Family-specific generators each export a conan-default preset. The
+        # checked-in presets are the single public entrypoint, so do not merge
+        # generated presets into the repository-root CMakeUserPresets.json.
+        toolchain.user_presets_path = None
         variables = toolchain.variables
         variables["BUILD_SHARED_LIBS"] = bool(self.options.shared)
         variables["BUILD_CORONA_EDITOR"] = bool(self.options.with_editor)
         variables["BUILD_CORONA_EXAMPLES"] = bool(self.options.with_examples)
         variables["BUILD_CORONA_TESTING"] = bool(self.options.with_tests)
         variables["CORONA_BUILD_VISION"] = bool(self.options.with_vision)
+        variables["VISION_BUILD_TESTS"] = bool(self.options.with_vision_tests)
         variables["VISION_BUILD_OIDN"] = bool(self.options.with_oidn)
         variables["CORONA_ENABLE_CEF"] = bool(self.options.with_cef)
 
@@ -104,7 +126,13 @@ class CoronaEngineConan(ConanFile):
 
         toolchain.generate()
 
+    def validate(self):
+        if bool(self.options.with_vision_tests) and not bool(self.options.with_vision):
+            raise ConanInvalidConfiguration("with_vision_tests=True requires with_vision=True")
+        if bool(self.options.with_oidn) and not bool(self.options.with_vision):
+            raise ConanInvalidConfiguration("with_oidn=True requires with_vision=True")
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()
-        cmake.build(target="corona_engine")
+        cmake.build(target="CoronaEngine")

--- a/misc/cmake/corona_dev_bootstrap.cmake
+++ b/misc/cmake/corona_dev_bootstrap.cmake
@@ -2,16 +2,31 @@ function(corona_dev_bootstrap)
     if(NOT DEFINED CORONA_DEV_CONFIGURATION OR CORONA_DEV_CONFIGURATION STREQUAL "")
         set(CORONA_DEV_CONFIGURATION "RelWithDebInfo" CACHE STRING "CoronaEngine developer configuration")
     endif()
+    if(NOT DEFINED CORONA_DEV_TARGET_FAMILY OR CORONA_DEV_TARGET_FAMILY STREQUAL "")
+        set(CORONA_DEV_TARGET_FAMILY "examples" CACHE STRING "CoronaEngine developer target family")
+    endif()
+
+    set_property(CACHE CORONA_DEV_TARGET_FAMILY PROPERTY STRINGS
+        core examples tests vision vision-tests vision-oidn)
+    set(_corona_target_families core examples tests vision vision-tests vision-oidn)
+    list(FIND _corona_target_families "${CORONA_DEV_TARGET_FAMILY}" _corona_target_family_index)
+    if(_corona_target_family_index EQUAL -1)
+        message(FATAL_ERROR
+            "Unsupported CORONA_DEV_TARGET_FAMILY='${CORONA_DEV_TARGET_FAMILY}'. "
+            "Expected one of: ${_corona_target_families}")
+    endif()
+
     string(TOLOWER "${CORONA_DEV_CONFIGURATION}" _corona_configuration_slug)
     set(_corona_toolchain
-        "${CMAKE_CURRENT_SOURCE_DIR}/build/conan/${_corona_configuration_slug}/generators/conan_toolchain.cmake")
+        "${CMAKE_CURRENT_SOURCE_DIR}/build/conan/${CORONA_DEV_TARGET_FAMILY}/${_corona_configuration_slug}/generators/conan_toolchain.cmake")
     set(_corona_build_environment
-        "${CMAKE_CURRENT_SOURCE_DIR}/build/conan/${_corona_configuration_slug}/generators/dev_build_environment.cmake")
+        "${CMAKE_CURRENT_SOURCE_DIR}/build/conan/${CORONA_DEV_TARGET_FAMILY}/${_corona_configuration_slug}/generators/dev_build_environment.cmake")
     if(NOT DEFINED ENV{CORONA_DEV_BOOTSTRAP_ACTIVE})
         find_program(_corona_uv uv REQUIRED)
         execute_process(
             COMMAND "${_corona_uv}" run --frozen python tools/dev.py _bootstrap
                     --configuration "${CORONA_DEV_CONFIGURATION}"
+                    --target-family "${CORONA_DEV_TARGET_FAMILY}"
             WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
             RESULT_VARIABLE _corona_bootstrap_result
             OUTPUT_VARIABLE _corona_bootstrap_stdout

--- a/src/systems/optics/CMakeLists.txt
+++ b/src/systems/optics/CMakeLists.txt
@@ -59,6 +59,16 @@ set_source_files_properties(
     PROPERTIES OBJECT_DEPENDS "${OPTICS_GIZMO_SHADER}"
 )
 
+# The Vision-enabled OpticsSystem translation unit exceeds MSVC's default COFF
+# section limit in Debug builds. Restrict /bigobj to that compiler and source
+# file so other toolchains and compilation units retain their normal flags.
+if(MSVC)
+    set_source_files_properties(
+        optics_system.cpp
+        PROPERTIES COMPILE_OPTIONS "/bigobj"
+    )
+endif()
+
 if((BUILD_CORONA_TESTING OR BUILD_TESTING) AND CORONA_BUILD_VISION)
     add_executable(corona_vision_model_normalization_tests
         tests/test_vision_model_normalization.cpp

--- a/tools/dev.py
+++ b/tools/dev.py
@@ -8,6 +8,8 @@ from horizon_workspace import ensure_workspace, update_workspace
 from workflow import (
     CONFIGURATIONS,
     DEFAULT_CONFIGURATION,
+    DEFAULT_TARGET_FAMILY,
+    TARGET_FAMILIES,
     CommandError,
     build_dir,
     clean_repo,
@@ -31,26 +33,86 @@ LOCAL_RECIPES = (
     "conan/recipes/ffmpeg",
 )
 RECIPE_TOGGLE_ENV = "CORONA_CONAN_EXPORT_LOCAL_RECIPES"
+TARGET_FAMILY_OPTIONS: dict[str, tuple[str, ...]] = {
+    "core": (
+        "&:with_examples=False", "&:with_tests=False", "&:with_vision=False",
+        "&:with_vision_tests=False", "&:with_oidn=False",
+    ),
+    "examples": (
+        "&:with_examples=True", "&:with_tests=False", "&:with_vision=True",
+        "&:with_vision_tests=False", "&:with_oidn=False",
+    ),
+    "tests": (
+        "&:with_examples=False", "&:with_tests=True", "&:with_vision=False",
+        "&:with_vision_tests=False", "&:with_oidn=False",
+    ),
+    "vision": (
+        "&:with_examples=False", "&:with_tests=False", "&:with_vision=True",
+        "&:with_vision_tests=False", "&:with_oidn=False",
+    ),
+    "vision-tests": (
+        "&:with_examples=False", "&:with_tests=True", "&:with_vision=True",
+        "&:with_vision_tests=True", "&:with_oidn=False",
+    ),
+    "vision-oidn": (
+        "&:with_examples=False", "&:with_tests=False", "&:with_vision=True",
+        "&:with_vision_tests=False", "&:with_oidn=True",
+    ),
+}
+VISION_TEST_TARGETS = {
+    "corona_vision_model_normalization_tests",
+    "corona_vision_render_mode_config_tests",
+    "corona_lightfield_geometry_tests",
+    "corona_vision_material_adapter_tests",
+    "corona_vision_pipeline_key_tests",
+    "corona_vision_scene_resource_tests",
+    "corona_vision_interop_lifetime_tests",
+    "corona_vision_geometry_gpu_resource_tests",
+}
 
 
-def conan_options(targets: list[str]) -> list[str]:
-    options: list[str] = []
-    lowered = [target.lower() for target in targets]
-    if any("test" in target for target in lowered):
-        options.append("&:with_tests=True")
-    if any("vision" in target or "oidn" in target for target in lowered):
-        options.append("&:with_vision=True")
-    if any("oidn" in target for target in lowered):
-        options.append("&:with_oidn=True")
-    return options
+def target_family_for_target(target: str) -> str:
+    lowered = target.lower()
+    if lowered in {"all", "corona_engine"}:
+        return "examples"
+    if lowered == "cp_oidn_cuda" or "oidn" in lowered:
+        return "vision-oidn"
+    if target.startswith("test-") or target.startswith("vision-test") or target in VISION_TEST_TARGETS:
+        return "vision-tests"
+    if target.startswith("vision-"):
+        return "vision"
+    if lowered.endswith("_tests") or target == "corona_ui_multisurface_smoke":
+        return "tests"
+    return "core"
 
 
-def install(configuration: str, targets: list[str], *, update: bool = False) -> None:
+def target_family_for_targets(targets: list[str]) -> str:
+    if not targets:
+        return DEFAULT_TARGET_FAMILY
+    families = {target_family_for_target(target) for target in targets}
+    if len(families) != 1:
+        choices = ", ".join(sorted(families))
+        raise ValueError(
+            f"Targets require different dependency families ({choices}). "
+            "Configure and build one target family at a time."
+        )
+    return families.pop()
+
+
+def conan_options(target_family: str) -> list[str]:
+    try:
+        return list(TARGET_FAMILY_OPTIONS[target_family])
+    except KeyError as error:
+        raise ValueError(f"Unsupported target family: {target_family}") from error
+
+
+def install(configuration: str, target_family: str, *, update: bool = False) -> None:
     ensure_workspace(REPO_ROOT)
     conan_install(
         REPO_ROOT,
         configuration,
-        options=conan_options(targets),
+        target_family=target_family,
+        options=conan_options(target_family),
         recipes=LOCAL_RECIPES,
         recipe_toggle_env=RECIPE_TOGGLE_ENV,
         update=update,
@@ -61,6 +123,7 @@ def execute(args: argparse.Namespace) -> None:
     targets = args.targets or [DEFAULT_TARGET]
     target = targets[0]
     configuration = args.configuration
+    target_family = args.target_family or target_family_for_targets(targets)
     if args.command == "status":
         run_command(("git", "status", "--short", "--branch"), cwd=REPO_ROOT)
         lock = ensure_workspace(REPO_ROOT)
@@ -68,26 +131,26 @@ def execute(args: argparse.Namespace) -> None:
         run_command(("conan", "--version"), cwd=REPO_ROOT)
         run_command(("cmake", "--list-presets"), cwd=REPO_ROOT)
     elif args.command in {"install", "_bootstrap"}:
-        install(configuration, targets)
+        install(configuration, target_family)
     elif args.command == "configure":
-        install(configuration, targets)
-        cmake_configure(REPO_ROOT, configuration)
+        install(configuration, target_family)
+        cmake_configure(REPO_ROOT, configuration, target_family)
     elif args.command == "build":
-        install(configuration, targets)
-        cmake_configure(REPO_ROOT, configuration)
-        cmake_build(REPO_ROOT, configuration, target)
+        install(configuration, target_family)
+        cmake_configure(REPO_ROOT, configuration, target_family)
+        cmake_build(REPO_ROOT, configuration, target, target_family)
     elif args.command == "build-fast":
         ensure_workspace(REPO_ROOT)
-        cmake_build(REPO_ROOT, configuration, target)
+        cmake_build(REPO_ROOT, configuration, target, target_family)
     elif args.command == "rebuild":
-        safe_remove(REPO_ROOT, build_dir(REPO_ROOT, configuration))
-        install(configuration, targets)
-        cmake_configure(REPO_ROOT, configuration)
-        cmake_build(REPO_ROOT, configuration, target)
+        safe_remove(REPO_ROOT, build_dir(REPO_ROOT, configuration, target_family))
+        install(configuration, target_family)
+        cmake_configure(REPO_ROOT, configuration, target_family)
+        cmake_build(REPO_ROOT, configuration, target, target_family)
     elif args.command == "update":
         update_workspace(REPO_ROOT)
-        install(configuration, targets, update=True)
-        cmake_configure(REPO_ROOT, configuration)
+        install(configuration, target_family, update=True)
+        cmake_configure(REPO_ROOT, configuration, target_family)
     elif args.command == "clean":
         clean_repo(REPO_ROOT)
     else:
@@ -102,6 +165,11 @@ def create_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("targets", nargs="*")
     parser.add_argument("--configuration", choices=CONFIGURATIONS, default=DEFAULT_CONFIGURATION)
+    parser.add_argument(
+        "--target-family",
+        choices=TARGET_FAMILIES,
+        help="Configure a named target family instead of inferring it from the build target.",
+    )
     return parser
 
 

--- a/tools/test_workflow.py
+++ b/tools/test_workflow.py
@@ -9,25 +9,49 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from horizon_workspace import load_lock
+from dev import conan_options, target_family_for_target, target_family_for_targets
 from workflow import (
+    DEFAULT_TARGET_FAMILY,
+    TARGET_FAMILIES,
     _cmake_bracket,
     _environment_value,
     _set_environment_value,
     build_dir,
     configuration_slug,
+    preset_name,
     safe_remove,
+    target_family_slug,
 )
 
 
 class WorkflowTests(unittest.TestCase):
-    def test_configuration_paths_are_per_configuration(self) -> None:
+    def test_configuration_paths_are_per_configuration_and_target_family(self) -> None:
         root = Path("C:/repo")
         self.assertEqual(configuration_slug("RelWithDebInfo"), "relwithdebinfo")
-        self.assertEqual(build_dir(root, "Debug"), root / "build" / "conan" / "debug")
+        self.assertEqual(DEFAULT_TARGET_FAMILY, "examples")
+        self.assertEqual(build_dir(root, "Debug", "core"), root / "build" / "conan" / "core" / "debug")
+        self.assertEqual(build_dir(root, "Debug"), root / "build" / "conan" / "examples" / "debug")
+        self.assertEqual(preset_name("vision-tests", "RelWithDebInfo"), "vision-tests-relwithdebinfo")
 
     def test_unknown_configuration_is_rejected(self) -> None:
         with self.assertRaises(ValueError):
             configuration_slug("Profile")
+        with self.assertRaises(ValueError):
+            target_family_slug("everything")
+
+    def test_target_family_mapping_and_options(self) -> None:
+        self.assertEqual(TARGET_FAMILIES, ("core", "examples", "tests", "vision", "vision-tests", "vision-oidn"))
+        self.assertEqual(target_family_for_target("CoronaEngine"), "core")
+        self.assertEqual(target_family_for_target("corona_engine"), "examples")
+        self.assertEqual(target_family_for_target("corona_resource_tests"), "tests")
+        self.assertEqual(target_family_for_target("vision-gui"), "vision")
+        self.assertEqual(target_family_for_target("test-render_graph"), "vision-tests")
+        self.assertEqual(target_family_for_target("CP_OIDN_CUDA"), "vision-oidn")
+        self.assertEqual(target_family_for_targets(["corona_engine"]), "examples")
+        with self.assertRaises(ValueError):
+            target_family_for_targets(["corona_engine", "CoronaEngine"])
+        self.assertIn("&:with_vision_tests=True", conan_options("vision-tests"))
+        self.assertIn("&:with_oidn=True", conan_options("vision-oidn"))
 
     def test_cmake_bracket_handles_embedded_delimiter(self) -> None:
         self.assertEqual(_cmake_bracket("a]]b"), "[=[a]]b]=]")

--- a/tools/workflow.py
+++ b/tools/workflow.py
@@ -9,6 +9,15 @@ from typing import Iterable, Mapping, Sequence
 
 CONFIGURATIONS = ("Debug", "Release", "RelWithDebInfo", "MinSizeRel")
 DEFAULT_CONFIGURATION = "RelWithDebInfo"
+TARGET_FAMILIES = (
+    "core",
+    "examples",
+    "tests",
+    "vision",
+    "vision-tests",
+    "vision-oidn",
+)
+DEFAULT_TARGET_FAMILY = "examples"
 BOOTSTRAP_ENV = "CORONA_DEV_BOOTSTRAP_ACTIVE"
 
 
@@ -25,12 +34,30 @@ def configuration_slug(configuration: str) -> str:
     return configuration.lower()
 
 
-def build_dir(repo_root: Path, configuration: str) -> Path:
-    return repo_root / "build" / "conan" / configuration_slug(configuration)
+def target_family_slug(target_family: str) -> str:
+    if target_family not in TARGET_FAMILIES:
+        raise ValueError(f"Unsupported target family: {target_family}")
+    return target_family
 
 
-def generators_dir(repo_root: Path, configuration: str) -> Path:
-    return build_dir(repo_root, configuration) / "generators"
+def preset_name(target_family: str, configuration: str) -> str:
+    return f"{target_family_slug(target_family)}-{configuration_slug(configuration)}"
+
+
+def build_dir(
+    repo_root: Path,
+    configuration: str,
+    target_family: str = DEFAULT_TARGET_FAMILY,
+) -> Path:
+    return repo_root / "build" / "conan" / target_family_slug(target_family) / configuration_slug(configuration)
+
+
+def generators_dir(
+    repo_root: Path,
+    configuration: str,
+    target_family: str = DEFAULT_TARGET_FAMILY,
+) -> Path:
+    return build_dir(repo_root, configuration, target_family) / "generators"
 
 
 def profile_path(repo_root: Path, configuration: str) -> Path:
@@ -80,17 +107,20 @@ def conan_install(
     repo_root: Path,
     configuration: str,
     *,
+    target_family: str,
     options: Iterable[str],
     recipes: Iterable[str],
     recipe_toggle_env: str,
     update: bool = False,
 ) -> None:
     export_local_recipes(repo_root, recipes, toggle_env=recipe_toggle_env)
+    target_family = target_family_slug(target_family)
     profile = profile_path(repo_root, configuration)
     if not profile.is_file():
         raise RuntimeError(f"Conan profile was not found: {profile}")
     command: list[str | os.PathLike[str]] = [
         "conan", "install", ".", "-pr:a", profile, "-pr:b", profile,
+        "-c:h", f"user.corona:target_family={target_family}",
     ]
     for option in options:
         command.extend(("-o", option))
@@ -98,12 +128,16 @@ def conan_install(
     if update:
         command.append("--update")
     run_command(command, cwd=repo_root)
-    write_cmake_build_environment(repo_root, configuration)
+    write_cmake_build_environment(repo_root, configuration, target_family)
 
 
-def load_conan_build_environment(repo_root: Path, configuration: str) -> dict[str, str]:
+def load_conan_build_environment(
+    repo_root: Path,
+    configuration: str,
+    target_family: str = DEFAULT_TARGET_FAMILY,
+) -> dict[str, str]:
     environment = dict(os.environ)
-    batch_file = generators_dir(repo_root, configuration) / "conanbuild.bat"
+    batch_file = generators_dir(repo_root, configuration, target_family) / "conanbuild.bat"
     if not batch_file.is_file():
         raise RuntimeError(f"Conan build environment was not found: {batch_file}")
     command = f'call "{batch_file}" >nul && set'
@@ -148,9 +182,13 @@ def _cmake_bracket(value: str) -> str:
     return f"[{equals}[{value}]{equals}]"
 
 
-def write_cmake_build_environment(repo_root: Path, configuration: str) -> Path:
-    environment = load_conan_build_environment(repo_root, configuration)
-    output = generators_dir(repo_root, configuration) / "dev_build_environment.cmake"
+def write_cmake_build_environment(
+    repo_root: Path,
+    configuration: str,
+    target_family: str = DEFAULT_TARGET_FAMILY,
+) -> Path:
+    environment = load_conan_build_environment(repo_root, configuration, target_family)
+    output = generators_dir(repo_root, configuration, target_family) / "dev_build_environment.cmake"
     names = (
         "PATH", "INCLUDE", "LIB", "LIBPATH", "VCINSTALLDIR", "VCToolsInstallDir",
         "VSINSTALLDIR", "WindowsSdkDir", "WindowsSDKVersion", "UniversalCRTSdkDir", "UCRTVersion",
@@ -164,10 +202,14 @@ def write_cmake_build_environment(repo_root: Path, configuration: str) -> Path:
     return output
 
 
-def cmake_configure(repo_root: Path, configuration: str) -> None:
-    environment = load_conan_build_environment(repo_root, configuration)
+def cmake_configure(
+    repo_root: Path,
+    configuration: str,
+    target_family: str = DEFAULT_TARGET_FAMILY,
+) -> None:
+    environment = load_conan_build_environment(repo_root, configuration, target_family)
     environment[BOOTSTRAP_ENV] = "1"
-    run_command(("cmake", "--preset", configuration_slug(configuration)), cwd=repo_root, env=environment)
+    run_command(("cmake", "--preset", preset_name(target_family, configuration)), cwd=repo_root, env=environment)
 
 
 def _cache_value(cache_file: Path, name: str) -> str | None:
@@ -178,8 +220,12 @@ def _cache_value(cache_file: Path, name: str) -> str | None:
     return None
 
 
-def assert_cache_matches_repo(repo_root: Path, configuration: str) -> None:
-    expected_build = build_dir(repo_root, configuration).resolve()
+def assert_cache_matches_repo(
+    repo_root: Path,
+    configuration: str,
+    target_family: str = DEFAULT_TARGET_FAMILY,
+) -> None:
+    expected_build = build_dir(repo_root, configuration, target_family).resolve()
     cache_file = expected_build / "CMakeCache.txt"
     if not cache_file.is_file():
         raise RuntimeError(f"CMake cache was not found: {cache_file}. Run configure/build first.")
@@ -191,11 +237,16 @@ def assert_cache_matches_repo(repo_root: Path, configuration: str) -> None:
         raise RuntimeError(f"CMake cache directory is '{cache_dir}', not '{expected_build}'. Run rebuild.")
 
 
-def cmake_build(repo_root: Path, configuration: str, target: str) -> None:
-    assert_cache_matches_repo(repo_root, configuration)
-    environment = load_conan_build_environment(repo_root, configuration)
+def cmake_build(
+    repo_root: Path,
+    configuration: str,
+    target: str,
+    target_family: str = DEFAULT_TARGET_FAMILY,
+) -> None:
+    assert_cache_matches_repo(repo_root, configuration, target_family)
+    environment = load_conan_build_environment(repo_root, configuration, target_family)
     run_command(
-        ("cmake", "--build", "--preset", configuration_slug(configuration), "--target", target),
+        ("cmake", "--build", "--preset", preset_name(target_family, configuration), "--target", target),
         cwd=repo_root,
         env=environment,
     )


### PR DESCRIPTION
## 内容

- 新增 core、examples、tests、vision、vision-tests、vision-oidn 六个目标族及四种构建配置的 CMake preset。
- 按目标族隔离 Conan 生成目录，并同步开发脚本、bootstrap 与 README。
- 启用 CoronaResource 测试构建，并为 Vision Debug 的大型编译单元增加 MSVC `/bigobj`。

## 验证

- `uv run --frozen python -m unittest tools/test_workflow.py`
- `ctest --test-dir build/conan/tests/debug -C Debug --output-on-failure -R ^ResourceManagerTests$`
- 已实际配置、构建并快速重建：core、examples、tests、vision、vision-tests。
- `cmake --list-presets`：28 个 preset。

## 已知限制

- `vision-oidn` 的 `openimagedenoise/2.3.3` 未在当前 Conan remote 中提供；按当前范围暂不新增自有 recipe 或 remote。